### PR TITLE
Add provider for AWS Route53 DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ export TF_VAR_cloudflare_email=<email>
 export TF_VAR_cloudflare_token=<token>
 ```
 
+#### Using AWS Route53 for DNS entries
+
+```sh
+export TF_VAR_domain=<domain> # e.g. example.org shall be already added to hosted zones.
+export TF_VAR_aws_access_key=<ACCESS_KEY>
+export TF_VAR_aws_secret_key=<SECRET_KEY>
+export TF_VAR_aws_region=<region> # e.g. eu-west-1
+```
+
 ### Usage
 
 ```sh

--- a/dns/aws/main.tf
+++ b/dns/aws/main.tf
@@ -1,0 +1,61 @@
+variable "count" {}
+
+variable "access_key" {}
+
+variable "secret_key" {}
+
+variable "region" {}
+
+variable "domain" {}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "public_ips" {
+  type = "list"
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  access_key = "${var.access_key}"
+  secret_key = "${var.secret_key}"
+  region     = "${var.region}"
+}
+
+data "aws_route53_zone" "selected_domain" {
+  name = "${var.domain}."
+}
+
+resource "aws_route53_record" "hosts" {
+  count = "${var.count}"
+
+  zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
+  name    = "${element(var.hostnames, count.index)}.${data.aws_route53_zone.selected_domain.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${element(var.public_ips, count.index)}"]
+}
+
+resource "aws_route53_record" "domain" {
+  zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
+
+  name    = "${data.aws_route53_zone.selected_domain.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${element(var.public_ips, 0)}"]
+}
+
+resource "aws_route53_record" "wildcard" {
+  depends_on = ["aws_route53_record.domain"]
+
+  zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
+  name    = "*"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${data.aws_route53_zone.selected_domain.name}"]
+}
+
+output "domains" {
+  value = ["${aws_route53_record.hosts.*.hostname}"]
+}

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ module "provider" {
   region          = "${var.digitalocean_region}"
 }*/
 
+/*
 module "dns" {
   source = "./dns/aws"
 
@@ -29,8 +30,8 @@ module "dns" {
   public_ips = "${module.provider.public_ips}"
   hostnames  = "${module.provider.hostnames}"
 }
+*/
 
-/*
 module "dns" {
   source = "./dns/cloudflare"
 
@@ -41,7 +42,6 @@ module "dns" {
   public_ips = "${module.provider.public_ips}"
   hostnames  = "${module.provider.hostnames}"
 }
-*/
 
 /*
 module "dns" {

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,19 @@ module "provider" {
 }*/
 
 module "dns" {
+  source = "./dns/aws"
+
+  count      = "${var.hosts}"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+  domain     = "${var.domain}"
+  public_ips = "${module.provider.public_ips}"
+  hostnames  = "${module.provider.hostnames}"
+}
+
+/*
+module "dns" {
   source = "./dns/cloudflare"
 
   count      = "${var.hosts}"
@@ -28,6 +41,7 @@ module "dns" {
   public_ips = "${module.provider.public_ips}"
   hostnames  = "${module.provider.hostnames}"
 }
+*/
 
 /*
 module "dns" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,19 @@ variable "digitalocean_region" {
   default = "nyc1"
 }
 
+/* aws */
+variable "aws_access_key" {
+  default = ""
+}
+
+variable "aws_secret_key" {
+  default = ""
+}
+
+variable "aws_region" {
+  default = "eu-west-1"
+}
+
 /* cloudflare */
 variable "cloudflare_email" {
   default = ""


### PR DESCRIPTION
To use aws route53 DNS provider, you will need to define "access_key", "secret_key" and "region" variables, and use the corresponding aws module block in main.tf by commenting out others.