### PR TITLE
Fixes k8s by using kubeadm 1.7.0. K8s Install fails due to latest 1.7.1

### DIFF
--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -7,4 +7,4 @@ deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF
 apt-get update
 apt-get install -y docker.io
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+apt-get install -y kubelet kubeadm=1.7.0-00 kubectl kubernetes-cni


### PR DESCRIPTION
Switch to previous stable release of kubeadm (1.7.0) while waiting for a fix (expected this week).
The kubeadm 1.7.1 update introduced a bug: https://github.com/kubernetes/kubeadm/issues/345