### PR TITLE
Fix issue for outputs does not have attr `list`

### DIFF
--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -78,11 +78,11 @@ data "template_file" "install" {
 data "null_data_source" "endpoints" {
   depends_on = ["null_resource.etcd"]
 
-  inputs {
+  inputs = {
     list = "${join(",", formatlist("http://%s:2379", var.vpn_ips))}"
   }
 }
 
 output "endpoints" {
-  value = ["${split(",", data.null_data_source.endpoints.outputs.list)}"]
+  value = ["${split(",", data.null_data_source.endpoints.outputs["list"])}"]
 }


### PR DESCRIPTION
Previously, while running the `terraform plan` command i was getting the
following error:

```
Error: Error running plan: 1 error(s) occurred:

* module.etcd.output.endpoints: Resource
'data.null_data_source.endpoints' does not have attribute 'outputs.list'
for variable 'data.null_data_source.endpoints.outputs.list'
```

After reading the documentation for data_source:
https://www.terraform.io/docs/providers/null/data_source.html

It was clear that outputs was a list.

Therefore, to access the list variable inside the outputs I
changed `ouputs.list` to `outputs["list"]`. This allows terraform to
access the attribute value of the outputs.

Also updated the `inputs {` to `inputs = {` to follow the example
provided in the referenced documentation.

This closes hobby-kube/provisioning#8