### PR TITLE
Add Gandi as a DNS service

### DIFF
--- a/dns/gandi/main.tf
+++ b/dns/gandi/main.tf
@@ -1,0 +1,49 @@
+variable "count" {}
+
+variable "api_key" {}
+
+variable "domain" {}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "public_ips" {
+  type = "list"
+}
+
+provider "gandi" {
+  key = "${var.api_key}"
+}
+
+resource "gandi_zone" "zone" {
+  name = "${var.domain} zone"
+}
+
+resource "gandi_zonerecord" "wildcard" {
+  zone = "${gandi_zone.zone.id}"
+  name = "*.kub"
+  type = "A"
+  ttl = 600
+  values = [
+    "${element(var.public_ips, 0)}"
+  ]
+}
+
+resource "gandi_zonerecord" "domain" {
+  count = "${var.count}"
+
+  zone = "${gandi_zone.zone.id}"
+  name    = "${element(var.hostnames, count.index)}"
+  type    = "A"
+  ttl = 600
+  values  = [
+    "${element(var.public_ips, count.index)}"
+  ]
+}
+
+
+resource "gandi_domainattachment" "gandi_domainattachment" {
+  domain = "${var.domain}"
+  zone = "${gandi_zone.zone.id}"
+}

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ module "provider" {
   hosts           = "${var.hosts}"
   hostname_format = "${var.hostname_format}"
   region          = "${var.scaleway_region}"
+  apt_packages    = "${var.apt_packages}"
 }
 
 /*module "provider" {
@@ -16,7 +17,20 @@ module "provider" {
   hosts           = "${var.hosts}"
   hostname_format = "${var.hostname_format}"
   region          = "${var.digitalocean_region}"
+  apt_packages    = "${var.apt_packages}"
 }*/
+
+/*
+module "dns" {
+  source = "./dns/gandi"
+
+  count      = "${var.hosts}"
+  domain     = "${var.domain}"
+  api_key    = "${var.gandi_api_key}"
+  public_ips = "${module.provider.public_ips}"
+  hostnames  = "${module.provider.hostnames}"
+}
+*/
 
 /*
 module "dns" {

--- a/provider/digitalocean/main.tf
+++ b/provider/digitalocean/main.tf
@@ -8,6 +8,10 @@ variable "ssh_keys" {
   type = "list"
 }
 
+variable "apt_packages" {
+  type = "string"
+}
+
 variable "hostname_format" {
   type = "string"
 }
@@ -46,7 +50,7 @@ resource "digitalocean_droplet" "host" {
     inline = [
       "until [ -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done",
       "apt-get update",
-      "apt-get install -yq nfs-common ceph-common",
+      "apt-get install -yq ${var.apt_packages}",
     ]
   }
 }

--- a/provider/scaleway/main.tf
+++ b/provider/scaleway/main.tf
@@ -6,6 +6,10 @@ variable "hosts" {
   default = 0
 }
 
+variable "apt_packages" {
+  type = "string"
+}
+
 variable "hostname_format" {
   type = "string"
 }
@@ -52,7 +56,7 @@ resource "scaleway_server" "host" {
   provisioner "remote-exec" {
     inline = [
       "apt-get update",
-      "apt-get install -yq apt-transport-https ufw nfs-common ceph-common",
+      "apt-get install -yq apt-transport-https ufw ${var.apt_packages}",
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,10 @@ variable "hostname_format" {
   default = "kube%d"
 }
 
+variable "apt_packages" {
+  default = "nfs-common ceph-common"
+}
+
 /* scaleway */
 variable "scaleway_organization" {
   default = ""
@@ -22,6 +26,11 @@ variable "scaleway_token" {
 
 variable "scaleway_region" {
   default = "ams1"
+}
+
+/* Gandi DNS */
+variable "gandi_api_key" {
+  default = ""
 }
 
 /* digitalocean */


### PR DESCRIPTION
As Gandi is a pretty good DNS provider and they have a brand new API, I suggest to give the possibility to add it in the list of available DNS providers.

I successfully tested this with the following Terraform provider for Gandi 
: https://github.com/tiramiseb/terraform-provider-gandi