### PR TITLE
Add DigitalOcean dns provider

### DIFF
--- a/dns/digitalocean/main.tf
+++ b/dns/digitalocean/main.tf
@@ -1,0 +1,49 @@
+variable "count" {}
+
+variable "token" {}
+
+variable "domain" {}
+
+variable "hostnames" {
+  type = "list"
+}
+
+variable "public_ips" {
+  type = "list"
+}
+
+provider "digitalocean" {
+  token = "${var.token}"
+}
+
+resource "digitalocean_record" "hosts" {
+  count = "${var.count}"
+
+  domain = "${var.domain}"
+  name   = "${element(var.hostnames, count.index)}"
+  value  = "${element(var.public_ips, count.index)}"
+  type   = "A"
+  ttl    = 300
+}
+
+resource "digitalocean_record" "domain" {
+  domain = "${var.domain}"
+  name   = "@"
+  value  = "${element(var.public_ips, 0)}"
+  type   = "A"
+  ttl    = 300
+}
+
+resource "digitalocean_record" "wildcard" {
+  depends_on = ["digitalocean_record.domain"]
+
+  domain = "${var.domain}"
+  name   = "*.${var.domain}."
+  value  = "@"
+  type   = "CNAME"
+  ttl    = 300
+}
+
+output "domains" {
+  value = ["${digitalocean_record.hosts.*.fqdn}"]
+}

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,18 @@ module "dns" {
 }
 */
 
+/*
+module "dns" {
+  source     = "./dns/digitalocean"
+  
+  count      = "${var.hosts}"
+  token      = "${var.digitalocean_token}"
+  domain     = "${var.domain}"
+  public_ips = "${module.provider.public_ips}"
+  hostnames  = "${module.provider.hostnames}"
+}
+*/
+
 module "swap" {
   source = "./service/swap"
 


### PR DESCRIPTION
I was using DigitalOcean for my cluster and I thought it would be nice to also be able to use their DNS, too, so I created a provider for it. This should really simplify things for anyone using DigitalOcean since it eliminates the need to set things up with an additional DNS provider on top the main cloud provider.