### PR TITLE
Add examples and instructions to help TF noobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Modules are using ssh-agent for remote operations. Add your SSH key with `ssh-ad
 
 ### Configuration
 
-**Important:** Modify only `/main.tf` in project root, comment or uncomment sections as needed. All variables in `/variables.tf` can be set
-either directly or by exporting evironment variables following the form `TF_VAR_<var_name>` (see `/variables.tf` for examples).
+**Important:** Modify only [main.tf](main.tf) in project root, comment or uncomment sections as needed. All variables in [variables.tf](variables.tf) can be set
+either directly or from evironment variable.
 
 Export the following environment variables depending on the modules you're using.
 
@@ -30,7 +30,7 @@ Export the following environment variables depending on the modules you're using
 #### Set Number of Machines (Nodes)
 
 ```sh
-export TF_VAR_node_count=5 # Defaults to 3
+export TF_VAR_node_count=3
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ export TF_VAR_node_count=5 # Defaults to 3
 export TF_VAR_hcloud_token=<token>
 export TF_VAR_hcloud_ssh_keys=<keys>
 # e.g.
-# export TF_VAR_hcloud_ssh_keys='["~/.ssh/id_rsa1.pub", "~/.ssh/id_rsa2.pub"]'
+# export TF_VAR_hcloud_ssh_keys='["My Desktop", "My Laptop"]'
+# These are the names you give your key after uploading it to the provider.
 ```
 
 
@@ -58,7 +59,8 @@ export TF_VAR_scaleway_token=<token>
 export TF_VAR_digitalocean_token=<token>
 export TF_VAR_digitalocean_ssh_keys=<keys>
 # e.g.
-# export TF_VAR_digitalocean_ssh_keys='["~/.ssh/id_rsa1.pub", "~/.ssh/id_rsa2.pub"]'
+# export TF_VAR_digitalocean_ssh_keys='["My Desktop", "My Laptop"]'
+# These are the names you give your key after uploading it to the provider.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Deploy a secure Kubernetes cluster on [Hetzner Cloud](https://www.hetzner.com/cloud), [Scaleway](https://www.scaleway.com/) or [DigitalOcean](https://www.digitalocean.com/) using [Terraform](https://www.terraform.io/).
 
+
 ## Setup
+
 
 ### Requirements
 
@@ -16,16 +18,31 @@ brew install terraform kubectl jq wireguard-tools
 
 Modules are using ssh-agent for remote operations. Add your SSH key with `ssh-add -K` if Terraform repeatedly fails to connect to remote hosts.
 
+
 ### Configuration
 
+**Important:** Modify only `/main.tf` in project root, comment or uncomment sections as needed. All variables in `/variables.tf` can be set
+either directly or by exporting evironment variables following the form `TF_VAR_<var_name>` (see `/variables.tf` for examples).
+
 Export the following environment variables depending on the modules you're using.
+
+
+#### Set Number of Machines (Nodes)
+
+```sh
+export TF_VAR_node_count=5 # Defaults to 3
+```
+
 
 #### Using Hetzner Cloud as provider
 
 ```sh
 export TF_VAR_hcloud_token=<token>
-export TF_VAR_hcloud_ssh_keys=<keys> # e.g. '["12548","17593"]'
+export TF_VAR_hcloud_ssh_keys=<keys>
+# e.g.
+# export TF_VAR_hcloud_ssh_keys='["~/.ssh/id_rsa1.pub", "~/.ssh/id_rsa2.pub"]'
 ```
+
 
 #### Using Scaleway as provider
 
@@ -34,12 +51,16 @@ export TF_VAR_scaleway_organization=<access_key>
 export TF_VAR_scaleway_token=<token>
 ```
 
+
 #### Using DigitalOcean as provider
 
 ```sh
 export TF_VAR_digitalocean_token=<token>
-export TF_VAR_digitalocean_ssh_keys=<keys> # e.g. '["121671", "1714133"]'
+export TF_VAR_digitalocean_ssh_keys=<keys>
+# e.g.
+# export TF_VAR_digitalocean_ssh_keys='["~/.ssh/id_rsa1.pub", "~/.ssh/id_rsa2.pub"]'
 ```
+
 
 #### Using Cloudflare for DNS entries
 
@@ -49,6 +70,7 @@ export TF_VAR_cloudflare_email=<email>
 export TF_VAR_cloudflare_token=<token>
 ```
 
+
 #### Using Amazon Route 53 for DNS entries
 
 ```sh
@@ -57,6 +79,7 @@ export TF_VAR_aws_access_key=<ACCESS_KEY>
 export TF_VAR_aws_secret_key=<SECRET_KEY>
 export TF_VAR_aws_region=<region> # e.g. eu-west-1
 ```
+
 
 #### Install additional APT packages
 
@@ -69,7 +92,8 @@ module "provider" {
 }
 ```
 
-### Usage
+
+### Execute
 
 ```sh
 # fetch the required modules
@@ -81,6 +105,7 @@ $ terraform plan
 # execute it
 $ terraform apply
 ```
+
 
 ## Using modules independently
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ module "provider" {
 
 ### Execute
 
+From the root of this project...
+
 ```sh
 # fetch the required modules
 $ terraform init

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
+
 # module "provider" {
 #   source = "./provider/scaleway"
 
 #   organization    = "${var.scaleway_organization}"
 #   token           = "${var.scaleway_token}"
-#   hosts           = "${var.hosts}"
+#   hosts           = "${var.node_count}"
 #   hostname_format = "${var.hostname_format}"
 #   region          = "${var.scaleway_region}"
 # }
@@ -11,7 +12,7 @@
 module "provider" {
   source = "./provider/hcloud"
 
-  hosts           = "${var.hosts}"
+  hosts           = "${var.node_count}"
   token           = "${var.hcloud_token}"
   type            = "${var.hcloud_type}"
   ssh_keys        = "${var.hcloud_ssh_keys}"
@@ -19,79 +20,73 @@ module "provider" {
   hostname_format = "${var.hostname_format}"
 }
 
-/*module "provider" {
-  source = "./provider/digitalocean"
+# module "provider" {
+#   source = "./provider/digitalocean"
 
-  token           = "${var.digitalocean_token}"
-  ssh_keys        = "${var.digitalocean_ssh_keys}"
-  hosts           = "${var.hosts}"
-  hostname_format = "${var.hostname_format}"
-  region          = "${var.digitalocean_region}"
-}*/
+#   token           = "${var.digitalocean_token}"
+#   ssh_keys        = "${var.digitalocean_ssh_keys}"
+#   hosts           = "${var.node_count}"
+#   hostname_format = "${var.hostname_format}"
+#   region          = "${var.digitalocean_region}"
+# }
 
-module "dns" {
-  source = "./dns/cloudflare"
+# module "dns" {
+#   source = "./dns/cloudflare"
 
-  count      = "${var.hosts}"
-  email      = "${var.cloudflare_email}"
-  token      = "${var.cloudflare_token}"
-  domain     = "${var.domain}"
-  public_ips = "${module.provider.public_ips}"
-  hostnames  = "${module.provider.hostnames}"
-}
+#   count      = "${var.node_count}"
+#   email      = "${var.cloudflare_email}"
+#   token      = "${var.cloudflare_token}"
+#   domain     = "${var.domain}"
+#   public_ips = "${module.provider.public_ips}"
+#   hostnames  = "${module.provider.hostnames}"
+# }
 
-/*
-module "dns" {
-  source = "./dns/aws"
+# module "dns" {
+#   source = "./dns/aws"
 
-  count      = "${var.hosts}"
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "${var.aws_region}"
-  domain     = "${var.domain}"
-  public_ips = "${module.provider.public_ips}"
-  hostnames  = "${module.provider.hostnames}"
-}
-*/
+#   count      = "${var.node_count}"
+#   access_key = "${var.aws_access_key}"
+#   secret_key = "${var.aws_secret_key}"
+#   region     = "${var.aws_region}"
+#   domain     = "${var.domain}"
+#   public_ips = "${module.provider.public_ips}"
+#   hostnames  = "${module.provider.hostnames}"
+# }
 
-/*
-module "dns" {
-  source = "./dns/google"
+# module "dns" {
+#   source = "./dns/google"
 
-  count        = "${var.hosts}"
-  project      = "${var.google_project}"
-  region       = "${var.google_region}"
-  creds_file   = "${var.google_credentials_file}"
-  managed_zone = "${var.google_managed_zone}"
-  domain       = "${var.domain}"
-  public_ips   = "${module.provider.public_ips}"
-  hostnames    = "${module.provider.hostnames}"
-}
-*/
+#   count        = "${var.node_count}"
+#   project      = "${var.google_project}"
+#   region       = "${var.google_region}"
+#   creds_file   = "${var.google_credentials_file}"
+#   managed_zone = "${var.google_managed_zone}"
+#   domain       = "${var.domain}"
+#   public_ips   = "${module.provider.public_ips}"
+#   hostnames    = "${module.provider.hostnames}"
+# }
 
-/*
-module "dns" {
-  source     = "./dns/digitalocean"
-  
-  count      = "${var.hosts}"
-  token      = "${var.digitalocean_token}"
-  domain     = "${var.domain}"
-  public_ips = "${module.provider.public_ips}"
-  hostnames  = "${module.provider.hostnames}"
-}
-*/
+# module "dns" {
+#   source     = "./dns/digitalocean"
+
+#   count      = "${var.node_count}"
+#   token      = "${var.digitalocean_token}"
+#   domain     = "${var.domain}"
+#   public_ips = "${module.provider.public_ips}"
+#   hostnames  = "${module.provider.hostnames}"
+# }
 
 module "swap" {
   source = "./service/swap"
 
-  count       = "${var.hosts}"
+  count       = "${var.node_count}"
   connections = "${module.provider.public_ips}"
 }
 
 module "wireguard" {
   source = "./security/wireguard"
 
-  count        = "${var.hosts}"
+  count        = "${var.node_count}"
   connections  = "${module.provider.public_ips}"
   private_ips  = "${module.provider.private_ips}"
   hostnames    = "${module.provider.hostnames}"
@@ -101,7 +96,7 @@ module "wireguard" {
 module "firewall" {
   source = "./security/ufw"
 
-  count                = "${var.hosts}"
+  count                = "${var.node_count}"
   connections          = "${module.provider.public_ips}"
   private_interface    = "${module.provider.private_network_interface}"
   vpn_interface        = "${module.wireguard.vpn_interface}"
@@ -112,7 +107,7 @@ module "firewall" {
 module "etcd" {
   source = "./service/etcd"
 
-  count       = "${var.hosts}"
+  count       = "${var.node_count}"
   connections = "${module.provider.public_ips}"
   hostnames   = "${module.provider.hostnames}"
   vpn_unit    = "${module.wireguard.vpn_unit}"
@@ -122,7 +117,7 @@ module "etcd" {
 module "kubernetes" {
   source = "./service/kubernetes"
 
-  count          = "${var.hosts}"
+  count          = "${var.node_count}"
   connections    = "${module.provider.public_ips}"
   cluster_name   = "${var.domain}"
   vpn_interface  = "${module.wireguard.vpn_interface}"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 
 # module "provider" {
 #   source = "./provider/scaleway"
-
+#
 #   organization    = "${var.scaleway_organization}"
 #   token           = "${var.scaleway_token}"
 #   hosts           = "${var.node_count}"
@@ -22,7 +22,7 @@ module "provider" {
 
 # module "provider" {
 #   source = "./provider/digitalocean"
-
+#
 #   token           = "${var.digitalocean_token}"
 #   ssh_keys        = "${var.digitalocean_ssh_keys}"
 #   hosts           = "${var.node_count}"
@@ -30,20 +30,20 @@ module "provider" {
 #   region          = "${var.digitalocean_region}"
 # }
 
-# module "dns" {
-#   source = "./dns/cloudflare"
+module "dns" {
+  source = "./dns/cloudflare"
 
-#   count      = "${var.node_count}"
-#   email      = "${var.cloudflare_email}"
-#   token      = "${var.cloudflare_token}"
-#   domain     = "${var.domain}"
-#   public_ips = "${module.provider.public_ips}"
-#   hostnames  = "${module.provider.hostnames}"
-# }
+  count      = "${var.node_count}"
+  email      = "${var.cloudflare_email}"
+  token      = "${var.cloudflare_token}"
+  domain     = "${var.domain}"
+  public_ips = "${module.provider.public_ips}"
+  hostnames  = "${module.provider.hostnames}"
+}
 
 # module "dns" {
 #   source = "./dns/aws"
-
+#
 #   count      = "${var.node_count}"
 #   access_key = "${var.aws_access_key}"
 #   secret_key = "${var.aws_secret_key}"
@@ -55,7 +55,7 @@ module "provider" {
 
 # module "dns" {
 #   source = "./dns/google"
-
+#
 #   count        = "${var.node_count}"
 #   project      = "${var.google_project}"
 #   region       = "${var.google_region}"
@@ -68,7 +68,7 @@ module "provider" {
 
 # module "dns" {
 #   source     = "./dns/digitalocean"
-
+#
 #   count      = "${var.node_count}"
 #   token      = "${var.digitalocean_token}"
 #   domain     = "${var.domain}"
@@ -79,7 +79,7 @@ module "provider" {
 module "swap" {
   source = "./service/swap"
 
-  count       = "${var.node_count}"
+  count       = "${var.hosts}"
   connections = "${module.provider.public_ips}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,8 @@ variable "hcloud_token" {
   default = ""
 }
 
-# export TF_VAR_hcloud_ssh_keys='["$(cat ~/.ssh/id_rsa_key1.pub)", "$(cat ~/.ssh/id_rsa_key2.pub)"]'
+# These are the names you give your key after uploading it to the provider.
+# export TF_VAR_hcloud_ssh_keys='["My Desktop", "My Laptop"]'
 variable "hcloud_ssh_keys" {
   default = []
 }
@@ -63,7 +64,8 @@ variable "digitalocean_token" {
   default = ""
 }
 
-# export TF_VAR_digitalocean_ssh_keys='["$(cat ~/.ssh/id_rsa_key1.pub)", "$(cat ~/.ssh/id_rsa_key2.pub)"]'
+# These are the names you give your key after uploading it to the provider.
+# export TF_VAR_digitalocean_ssh_keys='["My Desktop", "My Laptop"]'
 variable "digitalocean_ssh_keys" {
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,33 +1,24 @@
 
-/* GENERAL */
-
-# number of machines to provision
-# export TF_VAR_node_count=5
+/* general */
 variable "node_count" {
   default = 3
 }
 
 variable "domain" {
-  default = "example.com"
+  default = "stokebrain.com"
 }
 
 variable "hostname_format" {
   default = "kube%d"
 }
 
-
-/* HCLOUD */
-# see API docs for possible inputs: https://docs.hetzner.cloud/
-
-# export TF_VAR_hcloud_token=$(cat /my/secret/tokens/hcloud_token.txt)
+/* hcloud */
 variable "hcloud_token" {
   default = ""
 }
 
-# These are the names you give your key after uploading it to the provider.
-# export TF_VAR_hcloud_ssh_keys='["My Desktop", "My Laptop"]'
 variable "hcloud_ssh_keys" {
-  default = []
+  default = ["home_imac"]
 }
 
 variable "hcloud_location" {
@@ -38,15 +29,11 @@ variable "hcloud_type" {
   default = "cx11"
 }
 
-
-/* SCALEWAY */
-# see API docs for possible inputs: https://developer.scaleway.com/
-
+/* scaleway */
 variable "scaleway_organization" {
   default = ""
 }
 
-# export TF_VAR_scaleway_token=$(cat /my/secret/tokens/scaleway_token.txt)
 variable "scaleway_token" {
   default = ""
 }
@@ -55,17 +42,11 @@ variable "scaleway_region" {
   default = "ams1"
 }
 
-
-/* DIGITALOCEAN  */
-# see API docs for possible inputs: https://developers.digitalocean.com/documentation/v2/
-
-# export TF_VAR_digitalocean_token=$(cat /my/secret/tokens/digitalocean_token.txt)
+/* digitalocean  */
 variable "digitalocean_token" {
   default = ""
 }
 
-# These are the names you give your key after uploading it to the provider.
-# export TF_VAR_digitalocean_ssh_keys='["My Desktop", "My Laptop"]'
 variable "digitalocean_ssh_keys" {
   default = []
 }
@@ -74,9 +55,7 @@ variable "digitalocean_region" {
   default = "fra1"
 }
 
-
-/* AWS DNS */
-
+/* aws dns */
 variable "aws_access_key" {
   default = ""
 }
@@ -89,21 +68,16 @@ variable "aws_region" {
   default = "eu-west-1"
 }
 
-
-/* CLOUDFLARE DNS */
-
+/* cloudflare dns */
 variable "cloudflare_email" {
   default = ""
 }
 
-# export TF_VAR_cloudflare_token=$(cat /my/secret/tokens/cloudflare_token.txt)
 variable "cloudflare_token" {
   default = ""
 }
 
-
-/* GOOGLE DNS */
-
+/* google dns */
 variable "google_project" {
   default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,9 @@
-/* general */
-variable "hosts" {
+
+/* GENERAL */
+
+# number of machines to provision
+# export TF_VAR_node_count=5
+variable "node_count" {
   default = 3
 }
 
@@ -11,11 +15,15 @@ variable "hostname_format" {
   default = "kube%d"
 }
 
-/* hcloud */
+
+/* HCLOUD */
+
+# export TF_VAR_hcloud_token=$(cat /my/secret/tokens/hcloud_token.txt)
 variable "hcloud_token" {
   default = ""
 }
 
+# export TF_VAR_hcloud_ssh_keys='["$(cat ~/.ssh/id_rsa_key1.pub)", "$(cat ~/.ssh/id_rsa_key2.pub)"]'
 variable "hcloud_ssh_keys" {
   default = []
 }
@@ -28,11 +36,14 @@ variable "hcloud_type" {
   default = "cx11"
 }
 
-/* scaleway */
+
+/* SCALEWAY */
+
 variable "scaleway_organization" {
   default = ""
 }
 
+# export TF_VAR_scaleway_token=$(cat /my/secret/tokens/scaleway_token.txt)
 variable "scaleway_token" {
   default = ""
 }
@@ -41,11 +52,15 @@ variable "scaleway_region" {
   default = "ams1"
 }
 
-/* digitalocean */
+
+/* DIGITALOCEAN */
+
+# export TF_VAR_digitalocean_token=$(cat /my/secret/tokens/digitalocean_token.txt)
 variable "digitalocean_token" {
   default = ""
 }
 
+# export TF_VAR_digitalocean_ssh_keys='["$(cat ~/.ssh/id_rsa_key1.pub)", "$(cat ~/.ssh/id_rsa_key2.pub)"]'
 variable "digitalocean_ssh_keys" {
   default = []
 }
@@ -54,7 +69,9 @@ variable "digitalocean_region" {
   default = "fra1"
 }
 
-/* aws dns */
+
+/* AWS DNS */
+
 variable "aws_access_key" {
   default = ""
 }
@@ -67,16 +84,21 @@ variable "aws_region" {
   default = "eu-west-1"
 }
 
-/* cloudflare dns */
+
+/* CLOUDFLARE DNS */
+
 variable "cloudflare_email" {
   default = ""
 }
 
+# export TF_VAR_cloudflare_token=$(cat /my/secret/tokens/cloudflare_token.txt)
 variable "cloudflare_token" {
   default = ""
 }
 
-/* google dns */
+
+/* GOOGLE DNS */
+
 variable "google_project" {
   default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "hostname_format" {
 
 
 /* HCLOUD */
+# see API docs for possible inputs: https://docs.hetzner.cloud/
 
 # export TF_VAR_hcloud_token=$(cat /my/secret/tokens/hcloud_token.txt)
 variable "hcloud_token" {
@@ -38,6 +39,7 @@ variable "hcloud_type" {
 
 
 /* SCALEWAY */
+# see API docs for possible inputs: https://developer.scaleway.com/
 
 variable "scaleway_organization" {
   default = ""
@@ -53,7 +55,8 @@ variable "scaleway_region" {
 }
 
 
-/* DIGITALOCEAN */
+/* DIGITALOCEAN  */
+# see API docs for possible inputs: https://developers.digitalocean.com/documentation/v2/
 
 # export TF_VAR_digitalocean_token=$(cat /my/secret/tokens/digitalocean_token.txt)
 variable "digitalocean_token" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "hcloud_token" {
 }
 
 variable "hcloud_ssh_keys" {
-  default = ["home_imac"]
+  default = []
 }
 
 variable "hcloud_location" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "node_count" {
 }
 
 variable "domain" {
-  default = "stokebrain.com"
+  default = "example.com"
 }
 
 variable "hostname_format" {
@@ -42,7 +42,7 @@ variable "scaleway_region" {
   default = "ams1"
 }
 
-/* digitalocean  */
+/* digitalocean */
 variable "digitalocean_token" {
   default = ""
 }


### PR DESCRIPTION
@pstadler, thank you for this very helpful project. This is greatly reducing the learning curve for me.

Here are some changes which I feel would have added clarity for me. I'm a total noob to Terraform, and made some mistakes getting started with this project.

I missed the detail that the commands are to be run from the project root. I think this is because https://github.com/hobby-kube/guide links directly to the respective provider files. In spite of following the readme, I started off in `provider/hcloud`.

[update]
I don't have this working yet; probably best to hold off merging until it is. Seems I can't SSH in after the nodes are up, this is the error:
```
ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

Do I need this?
https://www.terraform.io/docs/providers/hcloud/index.html
https://github.com/terraform-providers/terraform-provider-hcloud

[update]
Fixed, needed to use `ssh-add -K` as described in the readme. Also encountered the following error, so pushed update for etcd version.
```
module.kubernetes.null_resource.kubernetes[0] (remote-exec): [init] using Kubernetes version: v1.11.1
module.kubernetes.null_resource.kubernetes[0] (remote-exec): [preflight] running pre-flight checks
module.kubernetes.null_resource.kubernetes[0] (remote-exec): 	[WARNING Swap]: running with swap on is not supported. Please disable swap
module.kubernetes.null_resource.kubernetes[0] (remote-exec): I0727 11:22:29.692161   11681 kernel_validator.go:81] Validating kernel version
module.kubernetes.null_resource.kubernetes[0] (remote-exec): I0727 11:22:29.692546   11681 kernel_validator.go:96] Validating kernel config

module.kubernetes.null_resource.kubernetes[0] (remote-exec): [preflight] Some fatal errors occurred:
module.kubernetes.null_resource.kubernetes[0] (remote-exec): 	[ERROR ExternalEtcdVersion]: this version of kubeadm only supports external etcd version >= 3.2.17. Current version: 3.2.13
module.kubernetes.null_resource.kubernetes[0] (remote-exec): 	[ERROR ExternalEtcdVersion]: this version of kubeadm only supports external etcd version >= 3.2.17. Current version: 3.2.13
module.kubernetes.null_resource.kubernetes[0] (remote-exec): 	[ERROR ExternalEtcdVersion]: this version of kubeadm only supports external etcd version >= 3.2.17. Current version: 3.2.13
module.kubernetes.null_resource.kubernetes[0] (remote-exec): [preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
```

Encountered more errors, for which I'll open issues and return to later.