### PR TITLE
Make compatible with k8s 1.12

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -72,7 +72,7 @@ data "template_file" "master-configuration" {
 
   vars {
     api_advertise_addresses = "${element(var.vpn_ips, 0)}"
-    etcd_endpoints          = "- ${join("\n  - ", var.etcd_endpoints)}"
+    etcd_endpoints          = "- ${join("\n    - ", var.etcd_endpoints)}"
     cert_sans               = "- ${element(var.connections, 0)}"
   }
 }

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -1,4 +1,4 @@
-apiVersion: kubeadm.k8s.io/v1alpha1
+apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 api:
   advertiseAddress: ${api_advertise_addresses}

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -3,8 +3,9 @@ kind: MasterConfiguration
 api:
   advertiseAddress: ${api_advertise_addresses}
 etcd:
-  endpoints:
-  ${etcd_endpoints}
+  external:
+    endpoints:
+    ${etcd_endpoints}
 apiServerCertSANs:
   ${cert_sans}
 kubeletConfiguration:


### PR DESCRIPTION
Ubuntu 16.04 now installs k8s 1.12.

The change with apiVersion is required or else you get this error:

```
root@kube1:~# kubeadm init --config /tmp/master-configuration.yml --ignore-preflight-errors=Swap
your configuration file uses an old API spec: "kubeadm.k8s.io/v1alpha1". Please use kubeadm v1.11 instead and run 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
```

The change to the etcd_endpoints is required as kuebadm doesn't realize you want to use external etcd without it and wants to install its own (which fails because it's already installed):

```
root@kube1:~# kubeadm init --config /tmp/master-configuration.yml --ignore-preflight-errors=Swap
[init] using Kubernetes version: v1.12.0
[preflight] running pre-flight checks
        [WARNING Swap]: running with swap on is not supported. Please disable swap
[preflight] Some fatal errors occurred:
        [ERROR Port-2379]: Port 2379 is in use
        [ERROR DirAvailable--var-lib-etcd]: /var/lib/etcd is not empty
```
