### PR TITLE
Debian/Ubuntu: install Linux headers which survive `apt upgrade`

### DIFF
--- a/security/wireguard/scripts/install-kernel-headers.sh
+++ b/security/wireguard/scripts/install-kernel-headers.sh
@@ -2,9 +2,9 @@
 set -e
 
 # Install kernel headers with apt
-if apt-cache show -q linux-headers-$(uname -r) > /dev/null 2>&1 /dev/null; then
+if apt-cache show -q linux-headers-generic > /dev/null 2>&1 /dev/null; then
   echo "Installing Linux headers using apt"
-  apt-get -yq install linux-headers-$(uname -r)
+  apt-get -yq install linux-headers-generic
   exit $?
 fi
 


### PR DESCRIPTION
When installing a specific `linux-headers` version, such as done using
`apt install linux-headers-$(uname -r)`, this specific version will be
pinned and not upgraded.

When installing `linux-headers-generic` instead, `apt upgrade` will pull
in the always latest version matching the `linux-image` Kernel
pkg/version.

This prevents situations where `wireguard` completely breaks after an
`apt upgrade` as DKMS is unable to rebuild `wireguard.ko` due to missing
recent Kernel headers.