### PR TITLE
Revert "Debian/Ubuntu: install Linux headers which survive `apt upgrade`"

### DIFF
--- a/security/wireguard/scripts/install-kernel-headers.sh
+++ b/security/wireguard/scripts/install-kernel-headers.sh
@@ -2,9 +2,9 @@
 set -e
 
 # Install kernel headers with apt
-if apt-cache show -q linux-headers-generic > /dev/null 2>&1 /dev/null; then
+if apt-cache show -q linux-headers-$(uname -r) > /dev/null 2>&1 /dev/null; then
   echo "Installing Linux headers using apt"
-  apt-get -yq install linux-headers-generic
+  apt-get -yq install linux-headers-$(uname -r)
   exit $?
 fi
 


### PR DESCRIPTION
Reverts hobby-kube/provisioning#34