### PR TITLE
Unable to run the latest version of Kubernetes(1.13.x) on Scaleway

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ export TF_VAR_hcloud_ssh_keys=<keys>
 ```sh
 export TF_VAR_scaleway_organization=<access_key>
 export TF_VAR_scaleway_token=<token>
+# e.g.
+# export TF_VAR_scaleway_type=START1-XS
+# export TF_VAR_scaleway_image="Ubuntu Mini Xenial 25G"
+
 ```
 
 #### Using DigitalOcean as provider

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,8 @@ module "provider" {
 #   token           = "${var.scaleway_token}"
 #   hostname_format = "${var.hostname_format}"
 #   region          = "${var.scaleway_region}"
+#   image           = "${var.scaleway_image}"
+#   type            = "${var.scaleway_type}"
 # }
 
 # module "provider" {

--- a/provider/scaleway/main.tf
+++ b/provider/scaleway/main.tf
@@ -46,6 +46,7 @@ resource "scaleway_server" "host" {
   image               = "${data.scaleway_image.image.id}"
   bootscript          = "${data.scaleway_bootscript.bootscript.id}"
   dynamic_ip_required = true
+#  enable_ipv6         = true
 
   count = "${var.hosts}"
 
@@ -85,5 +86,5 @@ output "private_ips" {
 }
 
 output "private_network_interface" {
-  value = "eth0"
+  value = "enp0s2"
 }

--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -17,7 +17,7 @@ variable "vpn_ips" {
 }
 
 variable "version" {
-  default = "v3.3.9"
+  default = "v3.3.10"
 }
 
 resource "null_resource" "etcd" {

--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -2,7 +2,7 @@
 set -e
 
 kubeadm init --config /tmp/master-configuration.yml \
-  --ignore-preflight-errors=Swap
+  --ignore-preflight-errors=Swap,NumCPU
 
 kubeadm token create ${token}
 

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -1,13 +1,19 @@
-apiVersion: kubeadm.k8s.io/v1alpha2
-kind: MasterConfiguration
-api:
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: InitConfiguration
+apiEndpoint:
   advertiseAddress: ${api_advertise_addresses}
+  bindPort: 6443
+---
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: ClusterConfiguration
+certificatesDir: /etc/kubernetes/pki
+apiServerCertSANs:
+  ${cert_sans}
 etcd:
   external:
     endpoints:
     ${etcd_endpoints}
-apiServerCertSANs:
-  ${cert_sans}
-kubeletConfiguration:
-  baseConfig:
-    failSwapOn: false
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+failSwapOn: false

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,14 @@ variable "scaleway_region" {
   default = "ams1"
 }
 
+variable "scaleway_type" {
+  default = ""
+}
+
+variable "scaleway_image" {
+  default = ""
+}
+
 /* digitalocean */
 variable "digitalocean_token" {
   default = ""


### PR DESCRIPTION
Ubuntu was changed interface names from ethX to enpXX