### PR TITLE
hcloud provider: fix apt lock detection

### DIFF
--- a/provider/hcloud/main.tf
+++ b/provider/hcloud/main.tf
@@ -44,9 +44,13 @@ resource "hcloud_server" "host" {
 
   provisioner "remote-exec" {
     inline = [
-      "while fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do sleep 1; done",
-      "apt-get update",
-      "apt-get install -yq ufw ${join(" ", var.apt_packages)}",
+      <<EOF
+while fuser /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+   sleep 1
+done
+apt-get update
+apt-get install -yq ufw ${join(" ", var.apt_packages)}
+EOF
     ]
   }
 }


### PR DESCRIPTION
### Context

Provisioning nodes on Hetzner with ubuntu-18.04 consistently failed for me at the remote-exec step that installs apt packages.

The most conspicuous error message said:

> Could not get lock /var/lib/apt/lists/lock

And further up in the log:

> Specified filename /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock does not exist.

### This fix

- The "Specified filename .. does not exist" error message can be replicated by running `fuser` against a non-existent file. `fuser` is invoked in the first inline script item
- [`#!/bin/sh`](https://github.com/hashicorp/terraform/blob/v0.11/communicator/ssh/communicator.go#L30) is added by default to remote-exec's inline scripts
- On the nodes that were created, `/bin/sh` is a symlink to `dash`
- [Looking at its man page](https://manpages.ubuntu.com/manpages/bionic/en/man1/dash.1.html), `dash` doesn't appear to support expanding curly braces

I couldn't find an alternate, smart way to do the equivalent of brace expansion in dash, so this PR simply spells out all the lock files that the curly braces expand to.

Switched to multiline-string because the line got uncomfortably long after expanding.