### PR TITLE
0.12 Terraform upgrade

### DIFF
--- a/dns/aws/main.tf
+++ b/dns/aws/main.tf
@@ -28,13 +28,13 @@ data "aws_route53_zone" "selected_domain" {
 }
 
 resource "aws_route53_record" "hosts" {
-  node_count = "${var.node_count}"
+  count = "${var.node_count}"
 
   zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
-  name    = "${element(var.hostnames, node_count.index)}.${data.aws_route53_zone.selected_domain.name}"
+  name    = "${element(var.hostnames, count.index)}.${data.aws_route53_zone.selected_domain.name}"
   type    = "A"
   ttl     = "300"
-  records = ["${element(var.public_ips, node_count.index)}"]
+  records = ["${element(var.public_ips, count.index)}"]
 }
 
 resource "aws_route53_record" "domain" {
@@ -57,5 +57,5 @@ resource "aws_route53_record" "wildcard" {
 }
 
 output "domains" {
-  value = ["${aws_route53_record.hosts.*.name}"]
+  value = "${aws_route53_record.hosts.*.name}"
 }

--- a/dns/aws/main.tf
+++ b/dns/aws/main.tf
@@ -1,4 +1,4 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "access_key" {}
 
@@ -28,13 +28,13 @@ data "aws_route53_zone" "selected_domain" {
 }
 
 resource "aws_route53_record" "hosts" {
-  count = "${var.count}"
+  node_count = "${var.node_count}"
 
   zone_id = "${data.aws_route53_zone.selected_domain.zone_id}"
-  name    = "${element(var.hostnames, count.index)}.${data.aws_route53_zone.selected_domain.name}"
+  name    = "${element(var.hostnames, node_count.index)}.${data.aws_route53_zone.selected_domain.name}"
   type    = "A"
   ttl     = "300"
-  records = ["${element(var.public_ips, count.index)}"]
+  records = ["${element(var.public_ips, node_count.index)}"]
 }
 
 resource "aws_route53_record" "domain" {

--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -1,4 +1,4 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "email" {}
 
@@ -20,11 +20,11 @@ provider "cloudflare" {
 }
 
 resource "cloudflare_record" "hosts" {
-  count = "${var.count}"
+  node_count = "${var.node_count}"
 
   domain  = "${var.domain}"
-  name    = "${element(var.hostnames, count.index)}"
-  value   = "${element(var.public_ips, count.index)}"
+  name    = "${element(var.hostnames, node_count.index)}"
+  value   = "${element(var.public_ips, node_count.index)}"
   type    = "A"
   proxied = false
 }

--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -20,11 +20,11 @@ provider "cloudflare" {
 }
 
 resource "cloudflare_record" "hosts" {
-  node_count = "${var.node_count}"
+  count = "${var.node_count}"
 
   domain  = "${var.domain}"
-  name    = "${element(var.hostnames, node_count.index)}"
-  value   = "${element(var.public_ips, node_count.index)}"
+  name    = "${element(var.hostnames, count.index)}"
+  value   = "${element(var.public_ips, count.index)}"
   type    = "A"
   proxied = false
 }
@@ -48,5 +48,5 @@ resource "cloudflare_record" "wildcard" {
 }
 
 output "domains" {
-  value = ["${cloudflare_record.hosts.*.hostname}"]
+  value = "${cloudflare_record.hosts.*.hostname}"
 }

--- a/dns/digitalocean/main.tf
+++ b/dns/digitalocean/main.tf
@@ -1,4 +1,4 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "token" {}
 
@@ -17,7 +17,7 @@ provider "digitalocean" {
 }
 
 resource "digitalocean_record" "hosts" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
   domain = "${var.domain}"
   name   = "${element(var.hostnames, count.index)}"

--- a/dns/digitalocean/main.tf
+++ b/dns/digitalocean/main.tf
@@ -45,5 +45,5 @@ resource "digitalocean_record" "wildcard" {
 }
 
 output "domains" {
-  value = ["${digitalocean_record.hosts.*.fqdn}"]
+  value = "${digitalocean_record.hosts.*.fqdn}"
 }

--- a/dns/google/main.tf
+++ b/dns/google/main.tf
@@ -1,4 +1,4 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "project" {}
 
@@ -25,7 +25,7 @@ provider "google" {
 }
 
 resource "google_dns_record_set" "hosts" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
   name         = "${element(var.hostnames, count.index)}.${var.domain}."
   type         = "A"
@@ -53,5 +53,5 @@ resource "google_dns_record_set" "wildcard" {
 }
 
 output "domains" {
-  value = ["${google_dns_record_set.hosts.*.name}"]
+  value = "${google_dns_record_set.hosts.*.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -37,14 +37,14 @@ module "provider" {
 module "swap" {
   source = "./service/swap"
 
-  count       = "${var.node_count}"
+  node_count       = "${var.node_count}"
   connections = "${module.provider.public_ips}"
 }
 
 module "dns" {
   source = "./dns/cloudflare"
 
-  count      = "${var.node_count}"
+  node_count      = "${var.node_count}"
   email      = "${var.cloudflare_email}"
   token      = "${var.cloudflare_token}"
   domain     = "${var.domain}"
@@ -55,7 +55,7 @@ module "dns" {
 # module "dns" {
 #   source = "./dns/aws"
 #
-#   count      = "${var.node_count}"
+#   node_count      = "${var.node_count}"
 #   access_key = "${var.aws_access_key}"
 #   secret_key = "${var.aws_secret_key}"
 #   region     = "${var.aws_region}"
@@ -67,7 +67,7 @@ module "dns" {
 # module "dns" {
 #   source = "./dns/google"
 #
-#   count        = "${var.node_count}"
+#   node_count        = "${var.node_count}"
 #   project      = "${var.google_project}"
 #   region       = "${var.google_region}"
 #   creds_file   = "${var.google_credentials_file}"
@@ -80,7 +80,7 @@ module "dns" {
 # module "dns" {
 #   source     = "./dns/digitalocean"
 #
-#   count      = "${var.node_count}"
+#   node_count      = "${var.node_count}"
 #   token      = "${var.digitalocean_token}"
 #   domain     = "${var.domain}"
 #   public_ips = "${module.provider.public_ips}"
@@ -90,7 +90,7 @@ module "dns" {
 module "wireguard" {
   source = "./security/wireguard"
 
-  count        = "${var.node_count}"
+  node_count        = "${var.node_count}"
   connections  = "${module.provider.public_ips}"
   private_ips  = "${module.provider.private_ips}"
   hostnames    = "${module.provider.hostnames}"
@@ -100,7 +100,7 @@ module "wireguard" {
 module "firewall" {
   source = "./security/ufw"
 
-  count                = "${var.node_count}"
+  node_count                = "${var.node_count}"
   connections          = "${module.provider.public_ips}"
   private_interface    = "${module.provider.private_network_interface}"
   vpn_interface        = "${module.wireguard.vpn_interface}"
@@ -111,7 +111,7 @@ module "firewall" {
 module "etcd" {
   source = "./service/etcd"
 
-  count       = "${var.etcd_node_count}"
+  node_count       = "${var.etcd_node_count}"
   connections = "${module.provider.public_ips}"
   hostnames   = "${module.provider.hostnames}"
   vpn_unit    = "${module.wireguard.vpn_unit}"
@@ -121,7 +121,7 @@ module "etcd" {
 module "kubernetes" {
   source = "./service/kubernetes"
 
-  count          = "${var.node_count}"
+  node_count          = "${var.node_count}"
   connections    = "${module.provider.public_ips}"
   cluster_name   = "${var.domain}"
   vpn_interface  = "${module.wireguard.vpn_interface}"

--- a/main.tf
+++ b/main.tf
@@ -37,14 +37,14 @@ module "provider" {
 module "swap" {
   source = "./service/swap"
 
-  node_count       = "${var.node_count}"
+  node_count  = "${var.node_count}"
   connections = "${module.provider.public_ips}"
 }
 
 module "dns" {
   source = "./dns/cloudflare"
 
-  node_count      = "${var.node_count}"
+  node_count = "${var.node_count}"
   email      = "${var.cloudflare_email}"
   token      = "${var.cloudflare_token}"
   domain     = "${var.domain}"
@@ -90,7 +90,7 @@ module "dns" {
 module "wireguard" {
   source = "./security/wireguard"
 
-  node_count        = "${var.node_count}"
+  node_count   = "${var.node_count}"
   connections  = "${module.provider.public_ips}"
   private_ips  = "${module.provider.private_ips}"
   hostnames    = "${module.provider.hostnames}"
@@ -100,7 +100,7 @@ module "wireguard" {
 module "firewall" {
   source = "./security/ufw"
 
-  node_count                = "${var.node_count}"
+  node_count           = "${var.node_count}"
   connections          = "${module.provider.public_ips}"
   private_interface    = "${module.provider.private_network_interface}"
   vpn_interface        = "${module.wireguard.vpn_interface}"
@@ -111,7 +111,7 @@ module "firewall" {
 module "etcd" {
   source = "./service/etcd"
 
-  node_count       = "${var.etcd_node_count}"
+  node_count  = "${var.etcd_node_count}"
   connections = "${module.provider.public_ips}"
   hostnames   = "${module.provider.hostnames}"
   vpn_unit    = "${module.wireguard.vpn_unit}"
@@ -121,7 +121,7 @@ module "etcd" {
 module "kubernetes" {
   source = "./service/kubernetes"
 
-  node_count          = "${var.node_count}"
+  node_count     = "${var.node_count}"
   connections    = "${module.provider.public_ips}"
   cluster_name   = "${var.domain}"
   vpn_interface  = "${module.wireguard.vpn_interface}"

--- a/provider/digitalocean/main.tf
+++ b/provider/digitalocean/main.tf
@@ -44,6 +44,13 @@ resource "digitalocean_droplet" "host" {
 
   count = "${var.hosts}"
 
+  connection {
+    user = "root"
+    type = "ssh"
+    timeout = "2m"
+    host = self.ipv4_address
+  }
+
   provisioner "remote-exec" {
     inline = [
       "until [ -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done",

--- a/provider/digitalocean/main.tf
+++ b/provider/digitalocean/main.tf
@@ -54,15 +54,15 @@ resource "digitalocean_droplet" "host" {
 }
 
 output "hostnames" {
-  value = ["${digitalocean_droplet.host.*.name}"]
+  value = "${digitalocean_droplet.host.*.name}"
 }
 
 output "public_ips" {
-  value = ["${digitalocean_droplet.host.*.ipv4_address}"]
+  value = "${digitalocean_droplet.host.*.ipv4_address}"
 }
 
 output "private_ips" {
-  value = ["${digitalocean_droplet.host.*.ipv4_address_private}"]
+  value = "${digitalocean_droplet.host.*.ipv4_address_private}"
 }
 
 output "private_network_interface" {

--- a/provider/hcloud/main.tf
+++ b/provider/hcloud/main.tf
@@ -38,9 +38,17 @@ resource "hcloud_server" "host" {
   location    = "${var.location}"
   image       = "${var.image}"
   server_type = "${var.type}"
-  ssh_keys    = ["${var.ssh_keys}"]
+  ssh_keys    = "${var.ssh_keys}"
 
   count = "${var.hosts}"
+
+  connection {
+    user = "root"
+    type = "ssh"
+    timeout = "2m"
+    host = self.ipv4_address
+  }
+
 
   provisioner "remote-exec" {
     inline = [
@@ -52,15 +60,15 @@ resource "hcloud_server" "host" {
 }
 
 output "hostnames" {
-  value = ["${hcloud_server.host.*.name}"]
+  value = "${hcloud_server.host.*.name}"
 }
 
 output "public_ips" {
-  value = ["${hcloud_server.host.*.ipv4_address}"]
+  value = "${hcloud_server.host.*.ipv4_address}"
 }
 
 output "private_ips" {
-  value = ["${hcloud_server.host.*.ipv4_address}"]
+  value = "${hcloud_server.host.*.ipv4_address}"
 }
 
 output "private_network_interface" {

--- a/provider/scaleway/main.tf
+++ b/provider/scaleway/main.tf
@@ -46,11 +46,6 @@ resource "scaleway_server" "host" {
 
   count = "${var.hosts}"
 
-  # volume = {
-  #   size_in_gb = "${var.storage_size}"
-  #   type       = "l_ssd"
-  # }
-
   connection {
     user = "root"
     type = "ssh"

--- a/provider/scaleway/main.tf
+++ b/provider/scaleway/main.tf
@@ -69,7 +69,7 @@ data "scaleway_image" "image" {
 
 data "scaleway_bootscript" "bootscript" {
   architecture = "x86_64"
-  name_filter  = "mainline 4.15.11 rev1"
+  name_filter  = "longterm 4.14 latest"
 }
 
 output "hostnames" {

--- a/provider/scaleway/main.tf
+++ b/provider/scaleway/main.tf
@@ -51,6 +51,14 @@ resource "scaleway_server" "host" {
   #   type       = "l_ssd"
   # }
 
+  connection {
+    user = "root"
+    type = "ssh"
+    timeout = "2m"
+    host = self.public_ip
+  }
+
+
   provisioner "remote-exec" {
     inline = [
       "apt-get update",
@@ -70,15 +78,15 @@ data "scaleway_bootscript" "bootscript" {
 }
 
 output "hostnames" {
-  value = ["${scaleway_server.host.*.name}"]
+  value = "${scaleway_server.host.*.name}"
 }
 
 output "public_ips" {
-  value = ["${scaleway_server.host.*.public_ip}"]
+  value = "${scaleway_server.host.*.public_ip}"
 }
 
 output "private_ips" {
-  value = ["${scaleway_server.host.*.private_ip}"]
+  value = "${scaleway_server.host.*.private_ip}"
 }
 
 output "private_network_interface" {

--- a/security/ufw/main.tf
+++ b/security/ufw/main.tf
@@ -1,4 +1,4 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "connections" {
   type = "list"
@@ -21,7 +21,7 @@ variable "kubernetes_interface" {
 }
 
 resource "null_resource" "firewall" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
   triggers = {
     template = "${data.template_file.ufw.rendered}"
@@ -34,16 +34,17 @@ resource "null_resource" "firewall" {
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-${data.template_file.ufw.rendered}
-EOF
+    inline = [
+      "${data.template_file.ufw.rendered}"
+    ]
+      
   }
 }
 
 data "template_file" "ufw" {
   template = "${file("${path.module}/scripts/ufw.sh")}"
 
-  vars {
+  vars = {
     private_interface    = "${var.private_interface}"
     kubernetes_interface = "${var.kubernetes_interface}"
     vpn_interface        = "${var.vpn_interface}"

--- a/security/wireguard/main.tf
+++ b/security/wireguard/main.tf
@@ -62,6 +62,7 @@ resource "null_resource" "wireguard" {
 
   provisioner "remote-exec" {
     inline = [
+      "DEBIAN_FRONTEND=noninteractive apt-get install -yq -o Dpkg::Options::=--force-confnew sudo",
       "DEBIAN_FRONTEND=noninteractive apt-get install -yq wireguard-dkms wireguard-tools",
     ]
   }

--- a/security/wireguard/main.tf
+++ b/security/wireguard/main.tf
@@ -151,7 +151,7 @@ data "template_file" "vpn_ips" {
 
 output "vpn_ips" {
   depends_on = ["null_resource.wireguard"]
-  value      = ["${data.template_file.vpn_ips.*.rendered}"]
+  value      = "${data.template_file.vpn_ips.*.rendered}"
 }
 
 output "vpn_unit" {

--- a/security/wireguard/main.tf
+++ b/security/wireguard/main.tf
@@ -1,4 +1,4 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "connections" {
   type = "list"
@@ -29,10 +29,10 @@ variable "vpn_iprange" {
 }
 
 resource "null_resource" "wireguard" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
-  triggers {
-    count = "${var.count}"
+  triggers =  {
+    count = "${var.node_count}"
   }
 
   connection {
@@ -101,10 +101,10 @@ resource "null_resource" "wireguard" {
 }
 
 data "template_file" "interface-conf" {
-  count    = "${var.count}"
+  count    = "${var.node_count}"
   template = "${file("${path.module}/templates/interface.conf")}"
 
-  vars {
+  vars = {
     address     = "${element(data.template_file.vpn_ips.*.rendered, count.index)}"
     port        = "${var.vpn_port}"
     private_key = "${element(data.external.keys.*.result.private_key, count.index)}"
@@ -113,10 +113,10 @@ data "template_file" "interface-conf" {
 }
 
 data "template_file" "peer-conf" {
-  count    = "${var.count}"
+  count    = "${var.node_count}"
   template = "${file("${path.module}/templates/peer.conf")}"
 
-  vars {
+  vars = {
     endpoint    = "${element(var.private_ips, count.index)}"
     port        = "${var.vpn_port}"
     public_key  = "${element(data.external.keys.*.result.public_key, count.index)}"
@@ -125,26 +125,26 @@ data "template_file" "peer-conf" {
 }
 
 data "template_file" "overlay-route-service" {
-  count    = "${var.count}"
+  count    = "${var.node_count}"
   template = "${file("${path.module}/templates/overlay-route.service")}"
 
-  vars {
+  vars = {
     address      = "${element(data.template_file.vpn_ips.*.rendered, count.index)}"
     overlay_cidr = "${var.overlay_cidr}"
   }
 }
 
 data "external" "keys" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
   program = ["sh", "${path.module}/scripts/gen_keys.sh"]
 }
 
 data "template_file" "vpn_ips" {
-  count    = "${var.count}"
+  count    = "${var.node_count}"
   template = "$${ip}"
 
-  vars {
+  vars = {
     ip = "${cidrhost(var.vpn_iprange, count.index + 1)}"
   }
 }

--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -89,5 +89,5 @@ data "null_data_source" "endpoints" {
 }
 
 output "endpoints" {
-  value = ["${split(",", data.null_data_source.endpoints.outputs["list"])}"]
+  value = "${split(",", data.null_data_source.endpoints.outputs["list"])}"
 }

--- a/service/kubernetes/kubectl.tf
+++ b/service/kubernetes/kubectl.tf
@@ -9,7 +9,7 @@ variable "api_secure_port" {
 resource "null_resource" "kubectl" {
   depends_on = ["null_resource.kubernetes"]
 
-  triggers {
+  triggers = {
     ip = "${element(var.vpn_ips, 0)}"
   }
 

--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -5,7 +5,7 @@ variable "connections" {
 }
 
 variable "vpn_ips" {
-  type = list(string)
+  type = "list"
 }
 
 variable "vpn_interface" {

--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -1,11 +1,11 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "connections" {
   type = "list"
 }
 
 variable "vpn_ips" {
-  type = "list"
+  type = list(string)
 }
 
 variable "vpn_interface" {
@@ -41,7 +41,7 @@ locals {
 }
 
 resource "null_resource" "kubernetes" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
   connection {
     host  = "${element(var.connections, count.index)}"
@@ -71,22 +71,22 @@ resource "null_resource" "kubernetes" {
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-  ${element(data.template_file.install.*.rendered, count.index)}
-  EOF
+    inline = [
+      "${element(data.template_file.install.*.rendered, count.index)}"
+    ]
   }
 
   provisioner "remote-exec" {
-    inline = <<EOF
-${count.index == 0 ? data.template_file.master.rendered : data.template_file.slave.rendered}
-EOF
+    inline = [
+      "${count.index == 0 ? data.template_file.master.rendered : data.template_file.slave.rendered}"
+    ]
   }
 }
 
 data "template_file" "master-configuration" {
   template = "${file("${path.module}/templates/master-configuration.yml")}"
 
-  vars {
+  vars = {
     api_advertise_addresses = "${element(var.vpn_ips, 0)}"
     etcd_endpoints          = "- ${join("\n    - ", var.etcd_endpoints)}"
     cert_sans               = "- ${element(var.connections, 0)}"
@@ -96,7 +96,7 @@ data "template_file" "master-configuration" {
 data "template_file" "master" {
   template = "${file("${path.module}/scripts/master.sh")}"
 
-  vars {
+  vars = {
     token = "${local.cluster_token}"
   }
 }
@@ -104,19 +104,19 @@ data "template_file" "master" {
 data "template_file" "slave" {
   template = "${file("${path.module}/scripts/slave.sh")}"
 
-  vars {
+  vars = {
     master_ip = "${element(var.vpn_ips, 0)}"
     token     = "${local.cluster_token}"
   }
 }
 
 data "template_file" "install" {
-  count    = "${var.count}"
+  count    = "${var.node_count}"
   template = "${file("${path.module}/scripts/install.sh")}"
 
-  vars {
+  vars = {
     vpn_interface = "${var.vpn_interface}"
-    vpn_ip        = "${element(var.vpn_ips, count.index)}"
+ #   vpn_ip        = "${element(var.vpn_ips, count.index)}"
     overlay_cidr  = "${var.overlay_cidr}"
   }
 }

--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -116,7 +116,6 @@ data "template_file" "install" {
 
   vars = {
     vpn_interface = "${var.vpn_interface}"
- #   vpn_ip        = "${element(var.vpn_ips, count.index)}"
     overlay_cidr  = "${var.overlay_cidr}"
   }
 }

--- a/service/swap/main.tf
+++ b/service/swap/main.tf
@@ -1,11 +1,11 @@
-variable "count" {}
+variable "node_count" {}
 
 variable "connections" {
   type = "list"
 }
 
 resource "null_resource" "swap" {
-  count = "${var.count}"
+  count = "${var.node_count}"
 
   connection {
     host  = "${element(var.connections, count.index)}"

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "scaleway_type" {
 }
 
 variable "scaleway_image" {
-  default = "Ubuntu Xenial"
+ default = "Ubuntu Bionic"
 }
 
 /* digitalocean */

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,8 @@ variable "hcloud_token" {
 }
 
 variable "hcloud_ssh_keys" {
-  default = []
+  type = list(string)
+  default = [""]
 }
 
 variable "hcloud_location" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,8 @@ variable "digitalocean_token" {
 }
 
 variable "digitalocean_ssh_keys" {
-  default = []
+  type = list(string)
+  default = [""]
 }
 
 variable "digitalocean_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,7 @@ variable "digitalocean_size" {
 }
 
 variable "digitalocean_image" {
-  default = "ubuntu-16-04-x64"
+  default = "ubuntu-18-04-x64"
 }
 
 /* aws dns */

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "hcloud_token" {
 }
 
 variable "hcloud_ssh_keys" {
-  type = list(string)
+  type    = list(string)
   default = [""]
 }
 
@@ -56,7 +56,7 @@ variable "scaleway_type" {
 }
 
 variable "scaleway_image" {
- default = "Ubuntu Bionic"
+  default = "Ubuntu Bionic"
 }
 
 /* digitalocean */
@@ -65,7 +65,7 @@ variable "digitalocean_token" {
 }
 
 variable "digitalocean_ssh_keys" {
-  type = list(string)
+  type    = list(string)
   default = [""]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "scaleway_region" {
 }
 
 variable "scaleway_type" {
-  default = "VC1S"
+  default = "DEV1-S"
 }
 
 variable "scaleway_image" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Status:

I have upgraded the core 0.12 differences to 0.11 including:
1. Reserved names
2. Explicit block vs resource definitions.
3. Removing list brackets to splat variables
4. Connection resource needs to set in 0.12 in digitalocean provider (was implicit in 0.11)

This has created a cluster on DO without DNS, though not fully tested.

to check:
1. Give other providers a run through to check for 0.12 syntax conflicts.
2. Test DNS