### PR TITLE
Update outdated Cloudflare provider & resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can get SSH key IDs using [this API](https://developers.digitalocean.com/doc
 ```sh
 export TF_VAR_domain=<domain> # e.g. example.org
 export TF_VAR_cloudflare_email=<email>
-export TF_VAR_cloudflare_token=<token>
+export TF_VAR_cloudflare_api_token=<token>
 ```
 
 #### Using Amazon Route 53 for DNS entries

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ module "dns" {
 
   node_count = "${var.node_count}"
   email      = "${var.cloudflare_email}"
-  token      = "${var.cloudflare_token}"
+  api_token  = "${var.cloudflare_api_token}"
   domain     = "${var.domain}"
   public_ips = "${module.provider.public_ips}"
   hostnames  = "${module.provider.hostnames}"

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,7 @@ variable "cloudflare_email" {
   default = ""
 }
 
-variable "cloudflare_token" {
+variable "cloudflare_api_token" {
   default = ""
 }
 


### PR DESCRIPTION
This makes Cloudflare provider to work again but now users need to provide the zone ID as specified in https://www.terraform.io/docs/providers/cloudflare/r/record.html. Docs updated accordingly.

Just tested it and works fine :)

Fix #50 