### PR TITLE
Bugfix: Switch API version for kubelet to v1beta1

### DIFF
--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -15,6 +15,6 @@ etcd:
     endpoints:
     ${etcd_endpoints}
 ---
-apiVersion: kubelet.config.k8s.io/v1beta2
+apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 failSwapOn: false


### PR DESCRIPTION
It looks like commit 558ecc1	introduced an incompatibility.

While bumping apiVersion for kubeadm to v1beta2 in master-configuration.yaml looks reasonable, the change to `kubelet.config.k8s.io/v1beta2` does not seem to be correct:

```
module.kubernetes.null_resource.kubernetes[0] (remote-exec): W1018 12:57:45.491711    8180 strict.go:47] unknown configuration schema.GroupVersionKind{Group:"kubelet.config.k8s.io", Version:"v1beta2", Kind:"KubeletConfiguration"} for scheme definitions in "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go:31" and "k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs/scheme.go:28"
module.kubernetes.null_resource.kubernetes[0] (remote-exec): unsupported apiVersion "kubelet.config.k8s.io/v1beta2", you may have to do manual conversion to "kubelet.config.k8s.io/v1beta1" and run kubeadm again
module.kubernetes.null_resource.kubernetes[0] (remote-exec): To see the stack trace of this error execute with --v=5 or higher
```

The provisioning then get stuck with

```
module.kubernetes.null_resource.kubernetes[2] (remote-exec): Waiting for API server to respond
```

This patch switches back to `kubelet.config.k8s.io/v1beta1`, which works as expected