### PR TITLE
Fix deprecated null_data_source

### DIFF
--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -64,7 +64,7 @@ data "template_file" "etcd-service" {
 
   vars = {
     hostname              = element(local.etcd_hostnames, count.index)
-    intial_cluster        = "${join(",", formatlist("%s=http://%s:2380", local.etcd_hostnames, local.etcd_vpn_ips))}"
+    initial_cluster        = "${join(",", formatlist("%s=http://%s:2380", local.etcd_hostnames, local.etcd_vpn_ips))}"
     listen_client_urls    = "http://${element(local.etcd_vpn_ips, count.index)}:2379"
     advertise_client_urls = "http://${element(local.etcd_vpn_ips, count.index)}:2379"
     listen_peer_urls      = "http://${element(local.etcd_vpn_ips, count.index)}:2380"

--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -80,14 +80,6 @@ data "template_file" "install" {
   }
 }
 
-data "null_data_source" "endpoints" {
-  depends_on = [null_resource.etcd]
-
-  inputs = {
-    list = "${join(",", formatlist("http://%s:2379", local.etcd_vpn_ips))}"
-  }
-}
-
 output "endpoints" {
-  value = "${split(",", data.null_data_source.endpoints.outputs["list"])}"
+  value = formatlist("http://%s:2379", local.etcd_vpn_ips)
 }

--- a/service/etcd/templates/etcd.service
+++ b/service/etcd/templates/etcd.service
@@ -9,7 +9,7 @@ ExecStart=/opt/etcd/etcd --name ${hostname} \
   --listen-client-urls "${listen_client_urls},http://localhost:2379" \
   --advertise-client-urls "${advertise_client_urls}" \
   --listen-peer-urls "${listen_peer_urls}" \
-  --initial-cluster "${intial_cluster}" \
+  --initial-cluster "${initial_cluster}" \
   --initial-advertise-peer-urls "${listen_peer_urls}" \
   --heartbeat-interval 200 \
   --election-timeout 5000


### PR DESCRIPTION
We can use locals instead of null_data_source.

```
│ Warning: Deprecated Resource
│ 
│   with module.etcd.data.null_data_source.endpoints,
│   on service/etcd/main.tf line 83, in data "null_data_source" "endpoints":
│   83: data "null_data_source" "endpoints" {
│ 
│ The null_data_source was historically used to construct intermediate values to re-use elsewhere in configuration, the same can now be achieved using locals
╵
```