### PR TITLE
Update size_slug for Digital Ocean

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "digitalocean_region" {
 }
 
 variable "digitalocean_size" {
-  default = "1gb"
+  default = "s-1vcpu-1gb"
 }
 
 variable "digitalocean_image" {


### PR DESCRIPTION
From the [List All Droplet Size](https://docs.digitalocean.com/reference/api/api-reference/#operation/list_all_sizes) API, the cheapest droplet size_slug is updated to `s-1vcpu-1gb`.

Included the API response for reference:

```json
{
  "slug": "s-1vcpu-1gb",
  "memory": 1024,
  "vcpus": 1,
  "disk": 25,
  "transfer": 1.0,
  "price_monthly": 5.0,
  "price_hourly": 0.00744,
  "regions": [
    "ams3",
    "blr1",
    "fra1",
    "lon1",
    "nyc1",
    "nyc3",
    "sfo3",
    "sgp1",
    "tor1"
  ],
  "available": true,
  "description": "Basic"
}
```