### PR TITLE
Support adding extra arguments and volumes for kube-apiserver

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -1,3 +1,19 @@
+variable "apiserver_extra_args" {
+  type = map
+
+  default = {}
+}
+
+variable "apiserver_extra_volumes" {
+  # Not specifying a `type` here since otherwise, Terraform may turn boolean values into strings
+  # and the server will not start (e.g., `"readOnly" = true` becomes stringified by `yamlencode`).
+  #
+  # This is a list of volume definitions.
+  # See https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-ControlPlaneComponent
+
+  default = []
+}
+
 variable "node_count" {}
 
 variable "connections" {
@@ -88,6 +104,8 @@ data "template_file" "master-configuration" {
 
   vars = {
     api_advertise_addresses = element(var.vpn_ips, 0)
+    apiserver_extra_args    = yamlencode(var.apiserver_extra_args)
+    apiserver_extra_volumes = yamlencode(var.apiserver_extra_volumes)
     etcd_endpoints          = "- ${join("\n    - ", var.etcd_endpoints)}"
     cert_sans               = "- ${element(var.connections, 0)}"
   }

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -10,6 +10,10 @@ certificatesDir: /etc/kubernetes/pki
 apiServer:
   certSANs:
   ${cert_sans}
+  extraArgs:
+    ${indent(4, apiserver_extra_args)}
+  extraVolumes:
+    ${indent(4, apiserver_extra_volumes)}
 etcd:
   external:
     endpoints:


### PR DESCRIPTION
With this, you can implement audit logging in a host directory, for example (https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/), or use other non-default features.

Example usage with Terraform:

```
resource "null_resource" "audit_policy" {
  connection {
    # Only on control plane (hobby-kube only creates one such node)
    host  = element(module.provider.public_ips, 0)
    user  = "root"
    agent = true
  }

  provisioner "remote-exec" {
    inline = ["[ -d /etc/kubernetes ] || mkdir -p /etc/kubernetes"]
  }

  provisioner "remote-exec" {
    inline = ["[ -d /var/log/kubernetes/audit ] || mkdir -p /var/log/kubernetes/audit/"]
  }

  provisioner "file" {
    content     = file("${path.module}/audit-policy.yaml")
    destination = "/etc/kubernetes/audit-policy.yaml"
  }
}

module "kubernetes" {
  # [...]

  apiserver_extra_args = {
    "audit-policy-file" = "/etc/kubernetes/audit-policy.yaml"
    "audit-log-path"    = "/var/log/kubernetes/audit/audit.log"
    "audit-log-maxage"    = "30" # maximum number of days to retain old audit log files
    "audit-log-maxsize"    = "100" # maximum size in megabytes of the audit log file before it gets rotated
  }
  apiserver_extra_volumes = [
    {
      name      = "audit-policy-file"
      hostPath  = "/etc/kubernetes/audit-policy.yaml"
      mountPath = "/etc/kubernetes/audit-policy.yaml"
      readOnly  = true
      pathType  = "File"
    },
    {
      name      = "audit-log-directory"
      hostPath  = "/var/log/kubernetes/audit"
      mountPath = "/var/log/kubernetes/audit"
      readOnly  = false
    }
  ]

  depends_on = [
    # Policy file must exist before kube-apiserver can start (see extra argument above)
    null_resource.audit_policy
  ]
}
```