### PR TITLE
Replace URL for Weave Net manifest

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -40,6 +40,11 @@ variable "overlay_cidr" {
   default = "10.96.0.0/16"
 }
 
+variable "weave_net_version" {
+  type = string
+  default = "v2.8.1"
+}
+
 resource "random_string" "token1" {
   length  = 6
   upper   = false
@@ -116,6 +121,7 @@ data "template_file" "master" {
 
   vars = {
     token = local.cluster_token
+    weave_net_version = var.weave_net_version
   }
 }
 

--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eux
 
 kubeadm init --config /tmp/master-configuration.yml \
   --ignore-preflight-errors=Swap,NumCPU
@@ -14,7 +14,7 @@ until nc -z localhost 6443; do
   sleep 5
 done
 
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+kubectl apply -f "https://github.com/weaveworks/weave/releases/download/${weave_net_version}/weave-daemonset-k8s.yaml"
 
 # See: https://kubernetes.io/docs/admin/authorization/rbac/
 kubectl create clusterrolebinding permissive-binding \


### PR DESCRIPTION
The host `cloud.weave.works` is gone, likely due to end of service (https://www.weave.works/blog/weave-cloud-end-of-service).