### PR TITLE
Support writing a separate kubeconfig file (which gets deleted on `terraform destroy`) instead of overwriting the default `~/.kube/config`

### DIFF
--- a/service/kubernetes/kubectl.tf
+++ b/service/kubernetes/kubectl.tf
@@ -6,11 +6,25 @@ variable "api_secure_port" {
   default = "6443"
 }
 
+variable "kubeconfig_file" {
+  type = string
+
+  # Defaults to overwriting the default file (typically `~/.kube/config`, but the environment
+  # variable `KUBECONFIG` overrides that so you may overwrite a file accidentally).
+  #
+  # If you want to store the kubeconfig configuration in a separate file, specify the file path.
+  # Only in that case, the file will be deleted upon `terraform destroy`.
+  default = ""
+}
+
 resource "null_resource" "kubectl" {
   depends_on = [null_resource.kubernetes]
 
   triggers = {
     ip = element(var.vpn_ips, 0)
+
+    # `when = destroy` provisioner does not allow using variables/locals directly, so work around that
+    kubeconfig_file = var.kubeconfig_file
   }
 
   provisioner "local-exec" {
@@ -27,6 +41,10 @@ EOT
 
   provisioner "local-exec" {
     command = <<EOT
+      if [ -n "${var.kubeconfig_file}" ]; then
+        export KUBECONFIG="${var.kubeconfig_file}"
+      fi
+
       kubectl config set-cluster ${var.cluster_name} \
       --certificate-authority=$HOME/.kube/${var.cluster_name}/ca.crt \
       --server=https://${element(var.connections, 0)}:${var.api_secure_port} \
@@ -48,5 +66,16 @@ EOT
 
   provisioner "local-exec" {
     command = "rm -rf $HOME/.kube/${var.cluster_name}"
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+
+    command = <<EOT
+      if [ -n "${self.triggers.kubeconfig_file}" ]; then
+        set -x
+        rm -fv "${self.triggers.kubeconfig_file}"
+      fi
+EOT
   }
 }


### PR DESCRIPTION
Putting all contexts into one file (the default `~/.kube/config`) seems to be what most people use since tools typically edit that file directly. However it's much safer to have separate files so that one cannot accidentally perform changes in the wrong environment (dev vs. prod, for example). Therefore I added an option to specify which files gets written. If not specified, the old default remains: write to the file specified by environment variable `KUBECONFIG`, or if not given the default file (`~/.kube/config` on Unix-like systems).

To avoid outdated leftover configs, the file gets deleted on cluster destruction (`terraform destroy`).

I have successfully used this strategy for a while to dynamically create files such as `~/.kube/my-project-{dev,prod}-{a,b}`, ensuring a consistent naming scheme.