### PR TITLE
Upgrade kubeadm configuration to avoid warnings

### DIFF
--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -1,10 +1,10 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: ${api_advertise_addresses}
   bindPort: 6443
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 certificatesDir: /etc/kubernetes/pki
 apiServer:


### PR DESCRIPTION
Converted using `kubeadm config migrate --old-config ... --new-config ...` and seemingly no fields changed name or value.

This is minor and only avoids some warnings during cluster bootstrapping.