### PR TITLE
Upgrade to Ubuntu 22.04 and Kubernetes 1.26, containerd, replace obsolete Terraform `template_file` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export TF_VAR_hcloud_ssh_keys='["<description-key1>", "<description-key2>"]'
 # Defaults:
 # export TF_VAR_hcloud_location="nbg1"
 # export TF_VAR_hcloud_type="cx11"
-# export TF_VAR_hcloud_image="ubuntu-20.04"
+# export TF_VAR_hcloud_image="ubuntu-22.04"
 ```
 
 SSH keys are referenced by their description. Visit the Hetzner Cloud console at
@@ -62,7 +62,7 @@ export TF_VAR_scaleway_secret_key=<secret_key>
 # Defaults:
 # export TF_VAR_scaleway_zone="nl-ams-1"
 # export TF_VAR_scaleway_type="DEV1-S"
-# export TF_VAR_scaleway_image="Ubuntu 20.04 Focal Fossa"
+# export TF_VAR_scaleway_image="Ubuntu 22.04 Jammy Jellyfish"
 
 ```
 
@@ -75,7 +75,7 @@ export TF_VAR_digitalocean_ssh_keys='["<id-key1>", "<id-key2>"]'
 # Defaults:
 # export TF_VAR_digitalocean_region="fra1"
 # export TF_VAR_digitalocean_size="1gb"
-# export TF_VAR_digitalocean_image="ubuntu-20-04-x64"
+# export TF_VAR_digitalocean_image="ubuntu-22-04-x64"
 ```
 
 You can get SSH key IDs using [this API](https://developers.digitalocean.com/documentation/v2/#list-all-keys).
@@ -88,7 +88,7 @@ export TF_VAR_packet_project_id=<uuid>
 # Defaults:
 # export TF_VAR_packet_facility="sjc1"
 # export TF_VAR_packet_plan="c1.small.x86"
-# export TF_VAR_packet_operating_system="ubuntu_20_04"
+# export TF_VAR_packet_operating_system="ubuntu_22_04"
 ```
 
 #### Using vSphere as provider
@@ -119,7 +119,7 @@ export TF_VAR_upcloud_ssh_keys='["<PUBLIC KEY HERE>"]'
 # Defaults:
 # export TF_VAR_upcloud_zone="de-fra1"
 # export TF_VAR_upcloud_plan="1xCPU-2GB"
-# export TF_VAR_upcloud_disk_template="Ubuntu Server 20.04 LTS (Focal Fossa)"
+# export TF_VAR_upcloud_disk_template="Ubuntu Server 22.04 LTS (Jammy Jellyfish)"
 ```
 
 You will need API credentials to use the UpCloud terraform provider, see https://upcloud.com/community/tutorials/getting-started-upcloud-api/ for more info.

--- a/provider/hcloud/main.tf
+++ b/provider/hcloud/main.tf
@@ -21,7 +21,7 @@ variable "image" {
 }
 
 variable "ssh_keys" {
-  type = list
+  type = list(string)
 }
 
 provider "hcloud" {
@@ -29,7 +29,7 @@ provider "hcloud" {
 }
 
 variable "apt_packages" {
-  type    = list
+  type    = list(string)
   default = []
 }
 
@@ -68,15 +68,15 @@ resource "hcloud_server" "host" {
 # }
 
 output "hostnames" {
-  value = "${hcloud_server.host.*.name}"
+  value = hcloud_server.host.*.name
 }
 
 output "public_ips" {
-  value = "${hcloud_server.host.*.ipv4_address}"
+  value = hcloud_server.host.*.ipv4_address
 }
 
 output "private_ips" {
-  value = "${hcloud_server.host.*.ipv4_address}"
+  value = hcloud_server.host.*.ipv4_address
 }
 
 output "private_network_interface" {

--- a/security/wireguard/templates/peer.conf
+++ b/security/wireguard/templates/peer.conf
@@ -1,4 +1,9 @@
+%{ for n in range(length(endpoints)) ~}
+%{ if n != exclude_index ~}
 [Peer]
-PublicKey = ${public_key}
-AllowedIps = ${allowed_ips}
-Endpoint = ${endpoint}:${port}
+PublicKey = ${element(public_keys, n)}
+AllowedIps = ${element(allowed_ips, n)}/32
+Endpoint = ${element(endpoints, n)}:${port}
+
+%{ endif ~}
+%{ endfor ~}

--- a/service/kubernetes/kubectl.tf
+++ b/service/kubernetes/kubectl.tf
@@ -34,7 +34,7 @@ resource "null_resource" "kubectl" {
   provisioner "local-exec" {
     command = <<EOT
       scp -oStrictHostKeyChecking=no \
-        root@${element(var.connections, 0)}:/etc/kubernetes/pki/{apiserver-kubelet-client.key,apiserver-kubelet-client.crt,ca.crt} \
+        root@"${element(var.connections, 0)}":/etc/kubernetes/pki/{apiserver-kubelet-client.key,apiserver-kubelet-client.crt,ca.crt} \
         $HOME/.kube/${var.cluster_name}
 EOT
   }

--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -1,10 +1,29 @@
 #!/bin/sh
 set -e
 
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
-EOF
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management (yes, `xenial` is correct even for newer Ubuntu versions)
+curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmour -o /etc/apt/keyrings/docker.gpg
+echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
 apt-get update
-apt-get install -y docker.io
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+
+
+# Use `DEBIAN_FRONTEND=noninteractive` to avoid starting containerd already with Ubuntu's minimal config.
+#
+# Kubernetes 1.26 requires at least containerd v1.6
+DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.6.15-1
+
+containerd config default > /etc/containerd/config.toml
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+systemctl enable containerd
+systemctl restart containerd
+
+# Pin Kubernetes major version since there are breaking changes between releases.
+# For example, Kubernetes 1.26 requires a newer containerd (https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#cri-api-removal).
+apt-get install -y kubelet=1.26.0-00 kubeadm=1.26.0-00 kubectl=1.26.0-00 # kubernetes-cni package comes as dependency of the others
+apt-mark hold kubelet kubeadm kubectl kubernetes-cni
+
+echo "Installation of packages done"

--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -1,21 +1,25 @@
 #!/bin/sh
-set -eux
+set -eu
 
+echo "kubeadm init"
 kubeadm init --config /tmp/master-configuration.yml \
   --ignore-preflight-errors=Swap,NumCPU
 
-kubeadm token create ${token}
+kubeadm token create "${token}"
 
 [ -d $HOME/.kube ] || mkdir -p $HOME/.kube
 ln -s /etc/kubernetes/admin.conf $HOME/.kube/config
 
+echo "Waiting for API server"
 until nc -z localhost 6443; do
   echo "Waiting for API server to respond"
   sleep 5
 done
 
+echo "Install CNI"
 kubectl apply -f "https://github.com/weaveworks/weave/releases/download/${weave_net_version}/weave-daemonset-k8s.yaml"
 
+echo "Add cluster role binding"
 # See: https://kubernetes.io/docs/admin/authorization/rbac/
 kubectl create clusterrolebinding permissive-binding \
   --clusterrole=cluster-admin \

--- a/service/kubernetes/scripts/slave.sh
+++ b/service/kubernetes/scripts/slave.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-set -e
+set -eu
 
-until $(nc -z ${master_ip} 6443); do
-  echo "Waiting for API server to respond"
+echo "Waiting for API server"
+until nc -z "${master_ip}" 6443; do
+  echo "Waiting for API server ${master_ip}:6443 to respond"
   sleep 5
 done
 
-kubeadm join --token=${token} ${master_ip}:6443 \
+kubeadm join --token="${token}" "${master_ip}:6443" \
   --discovery-token-unsafe-skip-ca-verification \
   --ignore-preflight-errors=Swap

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -1,7 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 localAPIEndpoint:
-  advertiseAddress: ${api_advertise_addresses}
+  advertiseAddress: ${api_advertise_address}
   bindPort: 6443
 ---
 apiVersion: kubeadm.k8s.io/v1beta3

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "hcloud_type" {
 }
 
 variable "hcloud_image" {
-  default = "ubuntu-20.04"
+  default = "ubuntu-22.04"
 }
 
 /* scaleway */
@@ -60,7 +60,7 @@ variable "scaleway_type" {
 }
 
 variable "scaleway_image" {
-  default = "Ubuntu 20.04 Focal Fossa"
+  default = "Ubuntu 22.04 Jammy Jellyfish"
 }
 
 /* digitalocean */
@@ -82,7 +82,7 @@ variable "digitalocean_size" {
 }
 
 variable "digitalocean_image" {
-  default = "ubuntu-20-04-x64"
+  default = "ubuntu-22-04-x64"
 }
 
 /* packet */
@@ -104,7 +104,7 @@ variable "packet_facility" {
 }
 
 variable "packet_operating_system" {
-  default = "ubuntu_20_04"
+  default = "ubuntu_22_04"
 }
 
 variable "packet_billing_cycle" {
@@ -221,7 +221,7 @@ variable "upcloud_plan" {
 }
 
 variable "upcloud_disk_template" {
-  default = "Ubuntu Server 20.04 LTS (Focal Fossa)"
+  default = "Ubuntu Server 22.04 LTS (Jammy Jellyfish)"
 }
 
 variable "upcloud_ssh_keys" {


### PR DESCRIPTION
The Terraform changes were required because the relevant provider is [obsolete](https://discuss.hashicorp.com/t/template-v2-2-0-does-not-have-a-package-available-mac-m1/35099/2) and not available for my platform (MacBook M1).

This change was tested on Hetzner Cloud.

With pinned package versions such as Kubernetes 1.26, we now get a very deterministic setup with no unintended breakage.