### PR TITLE
Remove non-required `cloudflare_email`, fixes #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ You will need API credentials to use the UpCloud terraform provider, see https:/
 
 ```sh
 export TF_VAR_domain=<domain> # e.g. example.org
-export TF_VAR_cloudflare_email=<email>
 export TF_VAR_cloudflare_api_token=<token>
 ```
 

--- a/dns/cloudflare/main.tf
+++ b/dns/cloudflare/main.tf
@@ -19,7 +19,6 @@ variable "public_ips" {
 }
 
 provider "cloudflare" {
-  email     = var.email
   api_token = var.api_token
 }
 

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,6 @@ module "dns" {
   source = "./dns/cloudflare"
 
   node_count = var.node_count
-  email      = var.cloudflare_email
   api_token  = var.cloudflare_api_token
   domain     = var.domain
   public_ips = module.provider.public_ips

--- a/variables.tf
+++ b/variables.tf
@@ -129,10 +129,6 @@ variable "aws_region" {
 }
 
 /* cloudflare dns */
-variable "cloudflare_email" {
-  default = ""
-}
-
 variable "cloudflare_api_token" {
   default = ""
 }


### PR DESCRIPTION
* Only `api_key` actually requires `email` and the provider now fails if we include `email` but not `api_key`. - We never actually needed to submit our email to the provider as we are using an api_token.

Due to https://github.com/cloudflare/terraform-provider-cloudflare/issues/1807

Fixes https://github.com/hobby-kube/provisioning/issues/84