### PR TITLE
Dearmour apt-key.gpg repo key for kubernetes repo, fixes #86

### DIFF
--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management (yes, `xenial` is correct even for newer Ubuntu versions)
-curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmour -o /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
* This is now presented as being ascii-armoured and apt apparently cannot handle ascii-armoured files

An update to the key was made at some point where it is now presented as ASCII armoured so it needs to be presented to apt as binary by piping through `gpg --dearmour`.

The official instructions refer to using gpg dearmour: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management.