### PR TITLE
Support Kubernetes 1.28, replace deprecated `null_data_source` by `local`, allow setting extra config in `KubeletConfiguration`

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -14,6 +14,15 @@ variable "apiserver_extra_volumes" {
   default = []
 }
 
+variable "kubelet_extra_config" {
+  # `map(any)` together with `yamlencode` might turn boolean values into strings, making the YAML
+  # invalid, so we instead support verbatim YAML input
+  type = string
+
+  description = "Extra config appended to KubeletConfiguration. Only applies at cluster creation."
+  default     = ""
+}
+
 variable "node_count" {}
 
 variable "connections" {
@@ -93,6 +102,7 @@ resource "null_resource" "kubernetes" {
       apiserver_extra_volumes = yamlencode(var.apiserver_extra_volumes)
       etcd_endpoints          = "- ${join("\n    - ", var.etcd_endpoints)}"
       cert_sans               = "- ${element(var.connections, 0)}"
+      kubelet_extra_config    = var.kubelet_extra_config
     })
     destination = "/tmp/master-configuration.yml"
   }

--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management (yes, `xenial` is correct even for newer Ubuntu versions)
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmour -o /etc/apt/keyrings/docker.gpg
@@ -13,8 +13,8 @@ apt-get update
 
 # Use `DEBIAN_FRONTEND=noninteractive` to avoid starting containerd already with Ubuntu's minimal config.
 #
-# Kubernetes 1.26 requires at least containerd v1.6
-DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.6.15-1
+# Kubernetes 1.26+ requires at least containerd v1.6.
+DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.6.22-1
 
 containerd config default > /etc/containerd/config.toml
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
@@ -23,7 +23,7 @@ systemctl restart containerd
 
 # Pin Kubernetes major version since there are breaking changes between releases.
 # For example, Kubernetes 1.26 requires a newer containerd (https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#cri-api-removal).
-apt-get install -y kubelet=1.26.0-00 kubeadm=1.26.0-00 kubectl=1.26.0-00 # kubernetes-cni package comes as dependency of the others
+apt-get install -y kubelet=1.28.0-00 kubeadm=1.28.1-00 kubectl=1.28.1-00 # kubernetes-cni package comes as dependency of the others
 apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 echo "Installation of packages done"

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -23,3 +23,4 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 failSwapOn: false
 cgroupDriver: systemd
+${kubelet_extra_config}


### PR DESCRIPTION
I've tested the new version without trouble on a new cluster, so it's really only a version bump. The `KubeletConfiguration` addition is helpful to enable feature gates such as [swap support](https://kubernetes.io/blog/2023/08/24/swap-linux-beta/).