### PR TITLE
Support arm64 installation of etcd

### DIFF
--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -38,11 +38,15 @@ resource "null_resource" "etcd" {
     agent = true
   }
 
+  provisioner "file" {
+    source      = "${path.module}/scripts/install.sh"
+    destination = "/tmp/install-etcd.sh"
+  }
+
   provisioner "remote-exec" {
     inline = [
-      templatefile("${path.module}/scripts/install.sh", {
-        version = var.etcd_version
-      })
+      "chmod +x /tmp/install-etcd.sh",
+      "/tmp/install-etcd.sh '${var.etcd_version}'"
     ]
   }
 

--- a/service/etcd/scripts/install.sh
+++ b/service/etcd/scripts/install.sh
@@ -1,9 +1,23 @@
 #!/bin/sh
-set -e
+set -eu
 
-rm -f /opt/etcd-${version}-linux-amd64.tar.gz
+[ $# = 1 ] || { >&2 echo "Usage: ${0} ETCD_VERSION"; exit 1; }
+
+version="${1}"
+if ! echo "${version}" | grep -qE '^v[0-9]'; then
+  >&2 printf "ERROR: Must provide valid etcd version, got \`%s\`\n" "${version}"
+  exit 1
+fi
+
+arch="$(arch | sed 's/x86_64/amd64/; s/aarch64/arm64/')"
+
+rm -f "/opt/etcd-${version}-linux-${arch}.tar.gz"
 rm -rf /opt/etcd && mkdir -p /opt/etcd
 
-curl -L https://storage.googleapis.com/etcd/${version}/etcd-${version}-linux-amd64.tar.gz \
-  -o /opt/etcd-${version}-linux-amd64.tar.gz
-tar xzvf /opt/etcd-${version}-linux-amd64.tar.gz -C /opt/etcd --strip-components=1
+(
+  set -x
+  curl --fail-with-body -L "https://storage.googleapis.com/etcd/${version}/etcd-${version}-linux-${arch}.tar.gz" \
+    -o "/opt/etcd-${version}-linux-${arch}.tar.gz"
+  tar xzvf "/opt/etcd-${version}-linux-${arch}.tar.gz" -C /opt/etcd --strip-components=1
+  rm "/opt/etcd-${version}-linux-${arch}.tar.gz"
+)


### PR DESCRIPTION
Towards https://github.com/hobby-kube/provisioning/issues/90

Fix hardcoded `amd64` and instead just look up the architecture of the host. Very likely, this also supports further CPU architectures. If Go were installed, we could use `go env GOARCH`, but it isn't and therefore we have to replace the output of the built-in `arch` binary (similar/equal to `uname -m` I think) to match Go's architecture names.

This changes the script from a Terraform template file to a plain file. It instead takes the etcd version as argument, which 1) makes local testing easier and 2) you don't have to escape `$` to `$$` because of Terraform.