### PR TITLE
make sure CPU architecture is configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export TF_VAR_scaleway_secret_key=<secret_key>
 # export TF_VAR_scaleway_zone="nl-ams-1"
 # export TF_VAR_scaleway_type="DEV1-S"
 # export TF_VAR_scaleway_image="Ubuntu 22.04 Jammy Jellyfish"
-
+# export TF_VAR_scaleway_image_architecture="x86_64"
 ```
 
 #### Using DigitalOcean as provider

--- a/main.tf
+++ b/main.tf
@@ -13,14 +13,15 @@ module "provider" {
 # module "provider" {
 #   source = "./provider/scaleway"
 #
-#   organization_id = var.scaleway_organization_id
-#   access_key      = var.scaleway_access_key
-#   secret_key      = var.scaleway_secret_key
-#   zone            = var.scaleway_zone
-#   type            = var.scaleway_type
-#   image           = var.scaleway_image
-#   hosts           = var.node_count
-#   hostname_format = var.hostname_format
+#   organization_id    = var.scaleway_organization_id
+#   access_key         = var.scaleway_access_key
+#   secret_key         = var.scaleway_secret_key
+#   zone               = var.scaleway_zone
+#   type               = var.scaleway_type
+#   image              = var.scaleway_image
+#   image_architecture = var.scaleway_image_architecture
+#   hosts              = var.node_count
+#   hostname_format    = var.hostname_format
 # }
 
 # module "provider" {
@@ -68,7 +69,7 @@ module "provider" {
 
 # module "provider" {
 #   source = "./provider/upcloud"
-# 
+#
 #   username        = var.upcloud_username
 #   password        = var.upcloud_password
 #   hosts           = var.node_count

--- a/provider/scaleway/main.tf
+++ b/provider/scaleway/main.tf
@@ -24,6 +24,10 @@ variable "image" {
   type = string
 }
 
+variable "image_architecture" {
+  type = string
+}
+
 variable "apt_packages" {
   type    = list(any)
   default = []
@@ -64,7 +68,7 @@ resource "scaleway_instance_server" "host" {
 }
 
 data "scaleway_instance_image" "image" {
-  architecture = "x86_64"
+  architecture = var.image_architecture
   name         = var.image
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,10 @@ variable "scaleway_image" {
   default = "Ubuntu 22.04 Jammy Jellyfish"
 }
 
+variable "scaleway_image_architecture" {
+  default = "x86_64"
+}
+
 /* digitalocean */
 variable "digitalocean_token" {
   default = ""


### PR DESCRIPTION
See https://github.com/hobby-kube/provisioning/issues/90

Looks like Scaleway is the only provider where CPU architecture was hardcoded in some way.