### PR TITLE
Upgrade to Ubuntu 22.04, Kubernetes 1.30.3, containerd 1.7.19, Cilium 1.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export TF_VAR_hcloud_ssh_keys='["<description-key1>", "<description-key2>"]'
 # Defaults:
 # export TF_VAR_hcloud_location="nbg1"
 # export TF_VAR_hcloud_type="cx11"
-# export TF_VAR_hcloud_image="ubuntu-22.04"
+# export TF_VAR_hcloud_image="ubuntu-24.04"
 ```
 
 SSH keys are referenced by their description. Visit the Hetzner Cloud console at
@@ -62,7 +62,7 @@ export TF_VAR_scaleway_secret_key=<secret_key>
 # Defaults:
 # export TF_VAR_scaleway_zone="nl-ams-1"
 # export TF_VAR_scaleway_type="DEV1-S"
-# export TF_VAR_scaleway_image="Ubuntu 22.04 Jammy Jellyfish"
+# export TF_VAR_scaleway_image="Ubuntu 24.04 Noble Numbat"
 # export TF_VAR_scaleway_image_architecture="x86_64"
 ```
 
@@ -75,7 +75,7 @@ export TF_VAR_digitalocean_ssh_keys='["<id-key1>", "<id-key2>"]'
 # Defaults:
 # export TF_VAR_digitalocean_region="fra1"
 # export TF_VAR_digitalocean_size="1gb"
-# export TF_VAR_digitalocean_image="ubuntu-22-04-x64"
+# export TF_VAR_digitalocean_image="ubuntu-24-04-x64"
 ```
 
 You can get SSH key IDs using [this API](https://developers.digitalocean.com/documentation/v2/#list-all-keys).
@@ -88,7 +88,7 @@ export TF_VAR_packet_project_id=<uuid>
 # Defaults:
 # export TF_VAR_packet_facility="sjc1"
 # export TF_VAR_packet_plan="c1.small.x86"
-# export TF_VAR_packet_operating_system="ubuntu_22_04"
+# export TF_VAR_packet_operating_system="ubuntu_24_04"
 ```
 
 #### Using vSphere as provider
@@ -119,7 +119,7 @@ export TF_VAR_upcloud_ssh_keys='["<PUBLIC KEY HERE>"]'
 # Defaults:
 # export TF_VAR_upcloud_zone="de-fra1"
 # export TF_VAR_upcloud_plan="1xCPU-2GB"
-# export TF_VAR_upcloud_disk_template="Ubuntu Server 22.04 LTS (Jammy Jellyfish)"
+# export TF_VAR_upcloud_disk_template="Ubuntu Server 24.04 LTS (Noble Numbat)"
 ```
 
 You will need API credentials to use the UpCloud terraform provider, see https://upcloud.com/community/tutorials/getting-started-upcloud-api/ for more info.

--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -51,7 +51,7 @@ variable "overlay_cidr" {
 
 variable "cilium_version" {
   type    = string
-  default = "1.14.1"
+  default = "1.16.0"
 }
 
 resource "random_string" "token1" {

--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 set -e
 
-# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management (yes, `xenial` is correct even for newer Ubuntu versions)
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmour -o /etc/apt/keyrings/docker.gpg
-echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+# https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --dearmour -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${VERSION_CODENAME}") stable" > /etc/apt/sources.list.d/docker.list
 
 apt-get update
 
@@ -14,16 +15,16 @@ apt-get update
 # Use `DEBIAN_FRONTEND=noninteractive` to avoid starting containerd already with Ubuntu's minimal config.
 #
 # Kubernetes 1.26+ requires at least containerd v1.6.
-DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.6.22-1
+DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.7.19-1
 
 containerd config default > /etc/containerd/config.toml
-sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml # https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd
 systemctl enable containerd
 systemctl restart containerd
 
 # Pin Kubernetes major version since there are breaking changes between releases.
 # For example, Kubernetes 1.26 requires a newer containerd (https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#cri-api-removal).
-apt-get install -y kubelet=1.28.0-00 kubeadm=1.28.1-00 kubectl=1.28.1-00 # kubernetes-cni package comes as dependency of the others
+apt-get install -y kubelet=1.30.3-1.1 kubeadm=1.30.3-1.1 kubectl=1.30.3-1.1 # kubernetes-cni package comes as dependency of the others
 apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 echo "Installation of packages done"

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "hcloud_type" {
 }
 
 variable "hcloud_image" {
-  default = "ubuntu-22.04"
+  default = "ubuntu-24.04"
 }
 
 /* scaleway */
@@ -60,7 +60,7 @@ variable "scaleway_type" {
 }
 
 variable "scaleway_image" {
-  default = "Ubuntu 22.04 Jammy Jellyfish"
+  default = "Ubuntu 24.04 Noble Numbat"
 }
 
 variable "scaleway_image_architecture" {
@@ -86,7 +86,7 @@ variable "digitalocean_size" {
 }
 
 variable "digitalocean_image" {
-  default = "ubuntu-22-04-x64"
+  default = "ubuntu-24-04-x64"
 }
 
 /* packet */
@@ -108,7 +108,7 @@ variable "packet_facility" {
 }
 
 variable "packet_operating_system" {
-  default = "ubuntu_22_04"
+  default = "ubuntu_24_04"
 }
 
 variable "packet_billing_cycle" {
@@ -221,7 +221,7 @@ variable "upcloud_plan" {
 }
 
 variable "upcloud_disk_template" {
-  default = "Ubuntu Server 22.04 LTS (Jammy Jellyfish)"
+  default = "Ubuntu Server 24.04 LTS (Noble Numbat)"
 }
 
 variable "upcloud_ssh_keys" {


### PR DESCRIPTION
Tested successfully on Hetzner. And yes, Kubernetes 1.31 is out today, but I did this last week 😆.