### PR TITLE
Update deprecated instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export TF_VAR_hcloud_ssh_keys=<keys>
 export TF_VAR_hcloud_ssh_keys='["<description-key1>", "<description-key2>"]'
 # Defaults:
 # export TF_VAR_hcloud_location="nbg1"
-# export TF_VAR_hcloud_type="cx11"
+# export TF_VAR_hcloud_type="cx22"
 # export TF_VAR_hcloud_image="ubuntu-24.04"
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "hcloud_location" {
 }
 
 variable "hcloud_type" {
-  default = "cx11"
+  default = "cx22"
 }
 
 variable "hcloud_image" {


### PR DESCRIPTION
Hetzner has deprecated [CX11 instances](https://docs.hetzner.com/cloud/servers/deprecated-plans/)
CX22 is the cheapest x86 instance now.