### PR TITLE
Upgrade to Kubernetes 1.31.0, containerd 1.7.20, etcd 3.5.21

### DIFF
--- a/service/etcd/main.tf
+++ b/service/etcd/main.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 variable "etcd_version" {
-  default = "v3.5.6"
+  default = "v3.5.21"
 }
 
 resource "null_resource" "etcd" {

--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -2,8 +2,8 @@
 set -e
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
 
 # https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --dearmour -o /etc/apt/keyrings/docker.gpg
@@ -15,7 +15,7 @@ apt-get update
 # Use `DEBIAN_FRONTEND=noninteractive` to avoid starting containerd already with Ubuntu's minimal config.
 #
 # Kubernetes 1.26+ requires at least containerd v1.6.
-DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.7.19-1
+DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.7.20-1
 
 containerd config default > /etc/containerd/config.toml
 sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml # https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd
@@ -24,7 +24,7 @@ systemctl restart containerd
 
 # Pin Kubernetes major version since there are breaking changes between releases.
 # For example, Kubernetes 1.26 requires a newer containerd (https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#cri-api-removal).
-apt-get install -y kubelet=1.30.3-1.1 kubeadm=1.30.3-1.1 kubectl=1.30.3-1.1 # kubernetes-cni package comes as dependency of the others
+apt-get install -y kubelet=1.31.0-1.1 kubeadm=1.31.0-1.1 kubectl=1.31.0-1.1 # kubernetes-cni package comes as dependency of the others
 apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 echo "Installation of packages done"


### PR DESCRIPTION
Kubernetes 1.31 graduates consistent cache reads to beta (https://kubernetes.io/blog/2024/08/15/consistent-read-from-cache-beta/) and therefore etcd 3.5.13+ is desired.

Sorry that the PR contains an older version of Kubernetes. I forgot to open the PR, but at least I've tested this version for a few months by now.

For etcd, I'm specifically choosing the latest v3.5, because

> Before upgrading to 3.6, make sure that all of your 3.5 members are updated to 3.5.20 or later. Updating will prevent the “too many learner member” error which causes upgrade to fail.

(source: [upgrade guide](https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/))