### PR TITLE
Support extra installation arguments for Cilium

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -54,6 +54,11 @@ variable "cilium_version" {
   default = "1.16.0"
 }
 
+variable "cilium_install_extra_args" {
+  type    = list(string)
+  default = []
+}
+
 resource "random_string" "token1" {
   length  = 6
   upper   = false
@@ -118,9 +123,10 @@ resource "null_resource" "kubernetes" {
       count.index == 0
       ? templatefile("${path.module}/scripts/master.sh",
         {
-          token          = local.cluster_token
-          cilium_version = var.cilium_version
-          overlay_cidr   = var.overlay_cidr
+          token                     = local.cluster_token
+          cilium_version            = var.cilium_version
+          cilium_install_extra_args = var.cilium_install_extra_args
+          overlay_cidr              = var.overlay_cidr
       })
       : templatefile("${path.module}/scripts/slave.sh",
         {

--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -24,7 +24,7 @@ sha256sum --check cilium-linux-$${CLI_ARCH}.tar.gz.sha256sum
 sudo tar xzvfC cilium-linux-$${CLI_ARCH}.tar.gz /usr/local/bin
 rm cilium-linux-$${CLI_ARCH}.tar.gz*
 
-cilium install --version ${cilium_version} --set ipam.mode=cluster-pool --set ipam.operator.clusterPoolIPv4PodCIDRList=${overlay_cidr}
+cilium install --version ${cilium_version} --set ipam.mode=cluster-pool --set ipam.operator.clusterPoolIPv4PodCIDRList=${overlay_cidr} %{ for arg in cilium_install_extra_args ~} ${arg} %{ endfor ~}
 cilium status --wait
 
 echo "Add cluster role binding"


### PR DESCRIPTION
I'm using this for `cilium_install_extra_args = ["--set", "kube-proxy-replacement=true"]` which is a prerequisite, for example, to use [Cilium `hostPort` support]((https://docs.cilium.io/en/latest/installation/cni-chaining-portmap/)) (in my case: as simple way to serve nginx-ingress on ports 80/443). Other Cilium installation options can be flexibly set in this way. Didn't take care of arguments containing spaces since I don't expect that to happen much.