### PR TITLE
Use latest kubeadm config API version (breaking change: `apiserver_extra_args` variable changes from dictionary to array)

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -1,7 +1,7 @@
 variable "apiserver_extra_args" {
-  type = map(any)
+  type = list(any) # example item: `{ name: "myarg", value: "myvalue" }`
 
-  default = {}
+  default = []
 }
 
 variable "apiserver_extra_volumes" {
@@ -9,7 +9,7 @@ variable "apiserver_extra_volumes" {
   # and the server will not start (e.g., `"readOnly" = true` becomes stringified by `yamlencode`).
   #
   # This is a list of volume definitions.
-  # See https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-ControlPlaneComponent
+  # See https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-ControlPlaneComponent
 
   default = []
 }

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -1,10 +1,10 @@
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: ${api_advertise_address}
   bindPort: 6443
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 certificatesDir: /etc/kubernetes/pki
 apiServer:


### PR DESCRIPTION
Avoid deprecation warnings