### PR TITLE
Ensure IPv4 forwarding is enabled before running kubeadm

### DIFF
--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
+# Required by kubeadm preflight checks
+echo "sysctl settings"
+grep -q net.ipv4.ip_forward=1 /etc/sysctl.conf || echo net.ipv4.ip_forward=1 >> /etc/sysctl.conf
+sysctl -p
+
 echo "kubeadm init"
 kubeadm init --config /tmp/master-configuration.yml \
   --ignore-preflight-errors=Swap,NumCPU


### PR DESCRIPTION
The sysctl is required by kubeadm preflight checks, but previously, depending on timing, may not have been set just yet.