### PR TITLE
Allow adding extra config to `ClusterConfiguration`

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -14,6 +14,15 @@ variable "apiserver_extra_volumes" {
   default = []
 }
 
+variable "kubeadm_extra_cluster_config" {
+  # `map(any)` together with `yamlencode` might turn boolean values into strings, making the YAML
+  # invalid, so we instead support verbatim YAML input
+  type = string
+
+  description = "Extra config appended to ClusterConfiguration. Only applies at cluster creation."
+  default     = ""
+}
+
 variable "kubelet_extra_config" {
   # `map(any)` together with `yamlencode` might turn boolean values into strings, making the YAML
   # invalid, so we instead support verbatim YAML input
@@ -102,12 +111,13 @@ resource "null_resource" "kubernetes" {
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/master-configuration.yml", {
-      api_advertise_address   = element(var.vpn_ips, 0)
-      apiserver_extra_args    = yamlencode(var.apiserver_extra_args)
-      apiserver_extra_volumes = yamlencode(var.apiserver_extra_volumes)
-      etcd_endpoints          = "- ${join("\n    - ", var.etcd_endpoints)}"
-      cert_sans               = "- ${element(var.connections, 0)}"
-      kubelet_extra_config    = var.kubelet_extra_config
+      api_advertise_address        = element(var.vpn_ips, 0)
+      apiserver_extra_args         = yamlencode(var.apiserver_extra_args)
+      apiserver_extra_volumes      = yamlencode(var.apiserver_extra_volumes)
+      etcd_endpoints               = "- ${join("\n    - ", var.etcd_endpoints)}"
+      cert_sans                    = "- ${element(var.connections, 0)}"
+      kubelet_extra_config         = var.kubelet_extra_config
+      kubeadm_extra_cluster_config = var.kubeadm_extra_cluster_config
     })
     destination = "/tmp/master-configuration.yml"
   }

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -1,3 +1,4 @@
+# https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 localAPIEndpoint:
@@ -18,6 +19,7 @@ etcd:
   external:
     endpoints:
     ${etcd_endpoints}
+${kubeadm_extra_cluster_config}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration


### PR DESCRIPTION
Example use case:

```
kubeadm_extra_cluster_config = <<-EOF
  proxy:
    disabled: true # disable kube-proxy (replaced by Cilium)
EOF

cilium_install_extra_args = [
  "--set", "kube-proxy-replacement=true"
]
```