### PR TITLE
Upgrade to Kubernetes 1.34.1, upgrade default Cilium version to 1.18.2

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -51,7 +51,7 @@ variable "overlay_cidr" {
 
 variable "cilium_version" {
   type    = string
-  default = "1.16.0"
+  default = "1.18.2"
 }
 
 variable "cilium_install_extra_args" {

--- a/service/kubernetes/scripts/install.sh
+++ b/service/kubernetes/scripts/install.sh
@@ -2,8 +2,8 @@
 set -e
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
 
 # https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --batch --yes --dearmour -o /etc/apt/keyrings/docker.gpg
@@ -13,8 +13,6 @@ apt-get update
 
 
 # Use `DEBIAN_FRONTEND=noninteractive` to avoid starting containerd already with Ubuntu's minimal config.
-#
-# Kubernetes 1.26+ requires at least containerd v1.6.
 DEBIAN_FRONTEND=noninteractive apt-get install -y containerd.io=1.7.27-1
 
 containerd config default > /etc/containerd/config.toml
@@ -24,7 +22,7 @@ systemctl restart containerd
 
 # Pin Kubernetes major version since there are breaking changes between releases.
 # For example, Kubernetes 1.26 requires a newer containerd (https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#cri-api-removal).
-apt-get install -y kubelet=1.33.2-1.1 kubeadm=1.33.2-1.1 kubectl=1.33.2-1.1 # kubernetes-cni package comes as dependency of the others
+apt-get install -y kubelet=1.34.1-1.1 kubeadm=1.34.1-1.1 kubectl=1.34.1-1.1 # kubernetes-cni package comes as dependency of the others
 apt-mark hold kubelet kubeadm kubectl kubernetes-cni
 
 echo "Installation of packages done"


### PR DESCRIPTION
These proved to work fine together (tested on Hetzner) and brings us the very latest versions