### PR TITLE
Switch `kubeadm join` to use a configuration file

### DIFF
--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -122,6 +122,14 @@ resource "null_resource" "kubernetes" {
     destination = "/tmp/master-configuration.yml"
   }
 
+  provisioner "file" {
+    content = templatefile("${path.module}/templates/worker-kubeadm-configuration.yml", {
+      control_plane_ip = element(var.vpn_ips, 0)
+      token            = local.cluster_token
+    })
+    destination = "/tmp/worker-kubeadm-configuration.yml"
+  }
+
   provisioner "remote-exec" {
     inline = [
       file("${path.module}/scripts/install.sh")
@@ -141,9 +149,14 @@ resource "null_resource" "kubernetes" {
       : templatefile("${path.module}/scripts/slave.sh",
         {
           master_ip = element(var.vpn_ips, 0)
-          token     = local.cluster_token
       })
     ]
+  }
+
+  provisioner "file" {
+    # Remove sensitive token from disk
+    content     = ""
+    destination = "/tmp/worker-kubeadm-configuration.yml"
   }
 }
 

--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -7,8 +7,7 @@ grep -q net.ipv4.ip_forward=1 /etc/sysctl.conf || echo net.ipv4.ip_forward=1 >> 
 sysctl -p
 
 echo "kubeadm init"
-kubeadm init --config /tmp/master-configuration.yml \
-  --ignore-preflight-errors=Swap,NumCPU
+kubeadm init --config /tmp/master-configuration.yml
 
 kubeadm token create "${token}"
 

--- a/service/kubernetes/scripts/slave.sh
+++ b/service/kubernetes/scripts/slave.sh
@@ -7,6 +7,5 @@ until nc -z "${master_ip}" 6443; do
   sleep 5
 done
 
-kubeadm join --token="${token}" "${master_ip}:6443" \
-  --discovery-token-unsafe-skip-ca-verification \
-  --ignore-preflight-errors=Swap
+echo "kubeadm join"
+kubeadm join --config /tmp/worker-kubeadm-configuration.yml

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -4,6 +4,10 @@ kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: ${api_advertise_address}
   bindPort: 6443
+nodeRegistration:
+  ignorePreflightErrors:
+    - NumCPU
+    - Swap
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration

--- a/service/kubernetes/templates/worker-kubeadm-configuration.yml
+++ b/service/kubernetes/templates/worker-kubeadm-configuration.yml
@@ -1,0 +1,11 @@
+# https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/#kubeadm-k8s-io-v1beta4-JoinConfiguration
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: JoinConfiguration
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: "${control_plane_ip}:6443"
+    token: "${token}"
+    unsafeSkipCAVerification: true
+nodeRegistration:
+  ignorePreflightErrors:
+    - Swap


### PR DESCRIPTION
The CRDs are easier to deal with, and if we want customizability, a YAML file is better than command line parameters