### PR TITLE
Support dual-stack cluster, upgrade to Cilium 1.19.5 to fix choosing link-local instead of the desired public IPv6 addresses for nodePort services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,11 +135,12 @@ module "dns" {
 module "wireguard" {
   source = "./security/wireguard"
 
-  node_count   = var.node_count
-  connections  = module.provider.public_ips
-  private_ips  = module.provider.private_ips
-  hostnames    = module.provider.hostnames
-  overlay_cidr = module.kubernetes.overlay_cidr
+  node_count        = var.node_count
+  connections       = module.provider.public_ips
+  private_ips       = module.provider.private_ips
+  hostnames         = module.provider.hostnames
+  overlay_cidr      = module.kubernetes.overlay_cidr
+  overlay_cidr_ipv6 = module.kubernetes.overlay_cidr_ipv6
 }
 
 module "firewall" {
@@ -171,5 +172,6 @@ module "kubernetes" {
   cluster_name   = var.domain
   vpn_interface  = module.wireguard.vpn_interface
   vpn_ips        = module.wireguard.vpn_ips
+  vpn_ips_ipv6   = module.wireguard.vpn_ips_ipv6
   etcd_endpoints = module.etcd.endpoints
 }

--- a/security/wireguard/main.tf
+++ b/security/wireguard/main.tf
@@ -24,8 +24,19 @@ variable "overlay_cidr" {
   type = string
 }
 
+variable "overlay_cidr_ipv6" {
+  type    = string
+  default = "" # empty means IPv6 is disabled
+}
+
 variable "vpn_iprange" {
   default = "10.0.1.0/24"
+}
+
+variable "vpn_iprange_ipv6" {
+  # Default is empty, meaning dual-stack support is disabled.
+  # Set to a ULA range like "fd00:10:0:1::/64" to enable dual-stack support.
+  default = ""
 }
 
 resource "null_resource" "wireguard" {
@@ -44,6 +55,7 @@ resource "null_resource" "wireguard" {
   provisioner "remote-exec" {
     inline = [
       "echo net.ipv4.ip_forward=1 >> /etc/sysctl.conf",
+      "%{if length(local.vpn_ips_ipv6) > 0}echo net.ipv6.conf.all.forwarding=1 >> /etc/sysctl.conf%{else}echo No IPv6%{endif}",
 
       "echo br_netfilter > /etc/modules-load.d/kubernetes.conf",
       "modprobe br_netfilter",
@@ -62,15 +74,17 @@ resource "null_resource" "wireguard" {
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/interface.conf", {
-      address     = element(local.vpn_ips, count.index)
-      port        = var.vpn_port
-      private_key = element(data.external.keys.*.result.private_key, count.index)
+      address      = element(local.vpn_ips, count.index)
+      address_ipv6 = length(local.vpn_ips_ipv6) == 0 ? "" : element(local.vpn_ips_ipv6, count.index)
+      port         = var.vpn_port
+      private_key  = element(data.external.keys.*.result.private_key, count.index)
       peers = templatefile("${path.module}/templates/peer.conf", {
-        exclude_index = count.index
-        endpoints     = var.private_ips
-        port          = var.vpn_port
-        public_keys   = data.external.keys.*.result.public_key
-        allowed_ips   = local.vpn_ips
+        exclude_index    = count.index
+        endpoints        = var.private_ips
+        port             = var.vpn_port
+        public_keys      = data.external.keys.*.result.public_key
+        allowed_ips      = local.vpn_ips
+        allowed_ips_ipv6 = local.vpn_ips_ipv6
       })
     })
     destination = "/etc/wireguard/${var.vpn_interface}.conf"
@@ -85,6 +99,7 @@ resource "null_resource" "wireguard" {
   provisioner "remote-exec" {
     inline = [
       "${join("\n", formatlist("echo '%s %s' >> /etc/hosts", local.vpn_ips, var.hostnames))}",
+      "%{if length(local.vpn_ips_ipv6) > 0}${join("\n", formatlist("echo '%s %s' >> /etc/hosts", local.vpn_ips_ipv6, var.hostnames))}%{else}echo No IPv6%{endif}",
       "systemctl is-enabled wg-quick@${var.vpn_interface} || systemctl enable wg-quick@${var.vpn_interface}",
       "systemctl daemon-reload",
       "systemctl restart wg-quick@${var.vpn_interface}",
@@ -93,8 +108,10 @@ resource "null_resource" "wireguard" {
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/overlay-route.service", {
-      address      = element(local.vpn_ips, count.index)
-      overlay_cidr = var.overlay_cidr
+      address           = element(local.vpn_ips, count.index)
+      address_ipv6      = length(local.vpn_ips_ipv6) > 0 ? element(local.vpn_ips_ipv6, count.index) : ""
+      overlay_cidr      = var.overlay_cidr
+      overlay_cidr_ipv6 = var.overlay_cidr_ipv6
     })
     destination = "/etc/systemd/system/overlay-route.service"
   }
@@ -119,11 +136,20 @@ locals {
     for n in range(var.node_count) :
     cidrhost(var.vpn_iprange, n + 1)
   ]
+  vpn_ips_ipv6 = length(var.vpn_iprange_ipv6) == 0 ? [] : [
+    for n in range(var.node_count) :
+    cidrhost(var.vpn_iprange_ipv6, n + 1)
+  ]
 }
 
 output "vpn_ips" {
   depends_on = [null_resource.wireguard]
   value      = local.vpn_ips
+}
+
+output "vpn_ips_ipv6" {
+  depends_on = [null_resource.wireguard]
+  value      = local.vpn_ips_ipv6
 }
 
 output "vpn_unit" {

--- a/security/wireguard/templates/interface.conf
+++ b/security/wireguard/templates/interface.conf
@@ -1,5 +1,5 @@
 [Interface]
-Address = ${address}
+Address = ${address}%{ if length(address_ipv6) > 0 },${address_ipv6}%{ endif }
 PrivateKey = ${private_key}
 ListenPort = ${port}
 

--- a/security/wireguard/templates/overlay-route.service
+++ b/security/wireguard/templates/overlay-route.service
@@ -6,6 +6,9 @@ After=wg-quick@wg0.service
 Type=oneshot
 User=root
 ExecStart=/sbin/ip route add ${overlay_cidr} dev wg0 src ${address}
+%{ if length(address_ipv6) > 0 }
+ExecStart=/sbin/ip -6 route add ${overlay_cidr_ipv6} dev wg0 src ${address_ipv6}
+%{ endif }
 
 [Install]
 WantedBy=multi-user.target

--- a/security/wireguard/templates/peer.conf
+++ b/security/wireguard/templates/peer.conf
@@ -2,7 +2,7 @@
 %{ if n != exclude_index ~}
 [Peer]
 PublicKey = ${element(public_keys, n)}
-AllowedIps = ${element(allowed_ips, n)}/32
+AllowedIps = ${element(allowed_ips, n)}/32%{ if length(allowed_ips_ipv6) > 0 },${element(allowed_ips_ipv6, n)}/128%{ endif }
 Endpoint = ${element(endpoints, n)}:${port}
 
 %{ endif ~}

--- a/service/kubernetes/main.tf
+++ b/service/kubernetes/main.tf
@@ -42,6 +42,13 @@ variable "vpn_ips" {
   type = list(any)
 }
 
+variable "vpn_ips_ipv6" {
+  # Empty means dual-stack is disabled, in which case no `--node-ip` is set and kubelet keeps
+  # auto-detecting the single (IPv4) node IP.
+  type    = list(any)
+  default = []
+}
+
 variable "vpn_interface" {
   type = string
 }
@@ -58,9 +65,28 @@ variable "overlay_cidr" {
   default = "10.96.0.0/16"
 }
 
+variable "overlay_cidr_ipv6" {
+  # Default is empty, meaning dual-stack support is disabled.
+  # Set to a ULA range like "fd00:10:244::/104" to enable dual-stack support.
+  default = ""
+}
+
+variable "service_cidr" {
+  # Matches kubeadm's default service subnet, used verbatim in the ClusterConfiguration
+  # only when dual-stack is enabled via `service_cidr_ipv6`.
+  default = "10.96.0.0/12"
+}
+
+variable "service_cidr_ipv6" {
+  # IPv6 range for cluster services. Empty disables dual-stack services, keeping kubeadm's
+  # single-stack default. When set, the kube-apiserver serves dual-stack services; the mask
+  # must be /108 or smaller (fewer addresses), e.g. "fd00:10:96::/108".
+  default = ""
+}
+
 variable "cilium_version" {
   type    = string
-  default = "1.19.1"
+  default = "1.19.5"
 }
 
 variable "cilium_install_extra_args" {
@@ -118,6 +144,9 @@ resource "null_resource" "kubernetes" {
       cert_sans                    = "- ${element(var.connections, 0)}"
       kubelet_extra_config         = var.kubelet_extra_config
       kubeadm_extra_cluster_config = var.kubeadm_extra_cluster_config
+      service_cidr                 = var.service_cidr
+      service_cidr_ipv6            = var.service_cidr_ipv6
+      node_ip                      = length(var.vpn_ips_ipv6) > 0 ? "${element(var.vpn_ips, 0)},${element(var.vpn_ips_ipv6, 0)}" : ""
     })
     destination = "/tmp/master-configuration.yml"
   }
@@ -126,6 +155,7 @@ resource "null_resource" "kubernetes" {
     content = templatefile("${path.module}/templates/worker-kubeadm-configuration.yml", {
       control_plane_ip = element(var.vpn_ips, 0)
       token            = local.cluster_token
+      node_ip          = length(var.vpn_ips_ipv6) > 0 ? "${element(var.vpn_ips, count.index)},${element(var.vpn_ips_ipv6, count.index)}" : ""
     })
     destination = "/tmp/worker-kubeadm-configuration.yml"
   }
@@ -145,6 +175,7 @@ resource "null_resource" "kubernetes" {
           cilium_version            = var.cilium_version
           cilium_install_extra_args = var.cilium_install_extra_args
           overlay_cidr              = var.overlay_cidr
+          overlay_cidr_ipv6         = var.overlay_cidr_ipv6
       })
       : templatefile("${path.module}/scripts/slave.sh",
         {
@@ -166,4 +197,8 @@ output "overlay_interface" {
 
 output "overlay_cidr" {
   value = var.overlay_cidr
+}
+
+output "overlay_cidr_ipv6" {
+  value = var.overlay_cidr_ipv6
 }

--- a/service/kubernetes/scripts/master.sh
+++ b/service/kubernetes/scripts/master.sh
@@ -28,7 +28,7 @@ sha256sum --check cilium-linux-$${CLI_ARCH}.tar.gz.sha256sum
 sudo tar xzvfC cilium-linux-$${CLI_ARCH}.tar.gz /usr/local/bin
 rm cilium-linux-$${CLI_ARCH}.tar.gz*
 
-cilium install --version ${cilium_version} --set ipam.mode=cluster-pool --set ipam.operator.clusterPoolIPv4PodCIDRList=${overlay_cidr} %{ for arg in cilium_install_extra_args ~} ${arg} %{ endfor ~}
+cilium install --version ${cilium_version} --set ipam.mode=cluster-pool --set ipam.operator.clusterPoolIPv4PodCIDRList=${overlay_cidr} %{ if length(overlay_cidr_ipv6) > 0 } --set ipv6.enabled=true --set ipam.operator.clusterPoolIPv6PodCIDRList='${overlay_cidr_ipv6}'%{ endif } %{ for arg in cilium_install_extra_args ~} ${arg} %{ endfor ~}
 cilium status --wait
 
 echo "Add cluster role binding"

--- a/service/kubernetes/templates/master-configuration.yml
+++ b/service/kubernetes/templates/master-configuration.yml
@@ -8,6 +8,11 @@ nodeRegistration:
   ignorePreflightErrors:
     - NumCPU
     - Swap
+%{ if node_ip != "" }
+  kubeletExtraArgs:
+    - name: node-ip
+      value: "${node_ip}"
+%{ endif }
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
@@ -23,6 +28,10 @@ etcd:
   external:
     endpoints:
     ${etcd_endpoints}
+%{ if service_cidr_ipv6 != "" }
+networking:
+  serviceSubnet: ${service_cidr},${service_cidr_ipv6}
+%{ endif }
 ${kubeadm_extra_cluster_config}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/service/kubernetes/templates/worker-kubeadm-configuration.yml
+++ b/service/kubernetes/templates/worker-kubeadm-configuration.yml
@@ -9,3 +9,8 @@ discovery:
 nodeRegistration:
   ignorePreflightErrors:
     - Swap
+%{ if node_ip != "" }
+  kubeletExtraArgs:
+    - name: node-ip
+      value: "${node_ip}"
+%{ endif }


### PR DESCRIPTION
https://github.com/hobby-kube/provisioning/pull/105 needs to be reviewed first since I stack this one on top of it to avoid merge conflicts.

This adds dualßstack (IPv4 + IPv6) support. I'm successfully using it with Envoy Gateway, Cilium and the hostPort feature to allow reaching my exposed applications through IPv6.